### PR TITLE
ReadMe Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ To use this alpha version you will need an argus instance running and listening 
 - To run argus in your own computer you should do:
     - argus -B localhost -F [slipsfolder]/argus.conf
 
-    This will run argus in your interface, open the port 902 in the localhost address only and run in background. See the argus configuration file and the Argus documentation for more information. (port 902 is used because is not in the default port list of nmap, so there are fewer chances that anybody will find it).
+    This will run argus in your interface, open the port 561 in the localhost address only and run in background. See the argus configuration file and the Argus documentation for more information. (port 561 is used because is not in the default port list of nmap, so there are fewer chances that anybody will find it).
 
 - Then you start the slips program receiving packets from a ra client.
 
-    ra -F [slipsfolder]/ra.conf -n -Z b -S 127.0.0.1:902 | ./slips.py -m models -p
+    ra -F [slipsfolder]/ra.conf -n -Z b -S 127.0.0.1:561 | [slipsfolder]/./slips.py -f [slipsfolder]/models -d
 
     This will read the network traffic in your computer and try to detect some malicious behavior by applying the models in the folder __models__.
 

--- a/argus.conf
+++ b/argus.conf
@@ -126,7 +126,7 @@ ARGUS_FLOW_KEY="CLASSIC_5_TUPLE"
 # Commandline equivalent   -P
 #
 
-ARGUS_ACCESS_PORT=1902
+ARGUS_ACCESS_PORT=561
 
 
 # When remote access is enabled (see above), you can specify that Argus


### PR DESCRIPTION
1.  Port has been changed to default argus port 561 in argus.conf as well as readme.
2. Options to specify the model and print the tuples has been updated according to the slips.py file.