### PR TITLE
Fix Typo in Create New Module Docs

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+stratosphereips.codedocs.com

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-stratosphereips.codedocs.com

--- a/docs/create_new_module.md
+++ b/docs/create_new_module.md
@@ -62,7 +62,7 @@ modules/
 
 The __init__.py is to make sure the module is treated as a python package, don't delete it.
 
-Remember to deleet the __pycache__ dir if it's copied to the new module using:
+Remember to delete the __pycache__ dir if it's copied to the new module using:
 
 ```rm -r modules/local_connection_detector/__pycache__```
 


### PR DESCRIPTION
* Detected typo mistake  in [create new module](https://stratospherelinuxips.readthedocs.io/en/develop/create_new_module.html) docs
* Changed **deleet** to **delete** for fixing typo mistake
