### PR TITLE
bumped xUbuntu repo version from 18.04 to 20.04

### DIFF
--- a/docker/dependency-image/Dockerfile
+++ b/docker/dependency-image/Dockerfile
@@ -66,8 +66,8 @@ RUN apt update && apt install -y --no-install-recommends \
 COPY requirements.txt ${SLIPS_DIR}/
 
 # Upgrade pip3 and install slips requirements
-RUN pip3 install --upgrade pip
-RUN pip3 install -r ${SLIPS_DIR}/requirements.txt
+RUN pip3 install --no-cache-dir --upgrade pip
+RUN pip3 install --no-cache-dir -r ${SLIPS_DIR}/requirements.txt
 
 
 CMD redis-server --daemonize yes && /bin/bash

--- a/docker/tensorflow-image/Dockerfile
+++ b/docker/tensorflow-image/Dockerfile
@@ -13,8 +13,8 @@ RUN apt update && apt install -y --no-install-recommends \
     git \
     curl \
     gnupg \
- && echo 'deb http://download.opensuse.org/repositories/security:/zeek/xUbuntu_18.04/ /' | tee /etc/apt/sources.list.d/security:zeek.list \
- && curl -fsSL https://download.opensuse.org/repositories/security:zeek/xUbuntu_18.04/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
+ && echo 'deb http://download.opensuse.org/repositories/security:/zeek/xUbuntu_20.04/ /' | tee /etc/apt/sources.list.d/security:zeek.list \
+ && curl -fsSL https://download.opensuse.org/repositories/security:zeek/xUbuntu_20.04/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
 
 # Install Slips dependencies.
 RUN apt update && apt install -y --no-install-recommends \

--- a/docker/tensorflow-image/Dockerfile
+++ b/docker/tensorflow-image/Dockerfile
@@ -6,6 +6,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Blocking module requirement to avoid using sudo
 ENV IS_IN_A_DOCKER_CONTAINER True
 
+ENV SLIPS_DIR /StratosphereLinuxIPS
+
+
 # Install wget and add Zeek repository to our sources.
 RUN apt update && apt install -y --no-install-recommends \
     wget \

--- a/docker/ubuntu-image/Dockerfile
+++ b/docker/ubuntu-image/Dockerfile
@@ -48,8 +48,8 @@ RUN (cd ${SLIPS_DIR} && chmod 774 slips.py)
 
 
 # Upgrade pip3 and install slips requirements
-RUN pip3 install --upgrade pip
-RUN pip3 install -r ${SLIPS_DIR}/requirements.txt
+RUN pip3 install --no-cache-dir --upgrade pip
+RUN pip3 install --no-cache-dir -r ${SLIPS_DIR}/requirements.txt
 
 
 # For Kalipso:


### PR DESCRIPTION
* Since xUbuntu 18.04 doesn't exist anymore at [http://download.opensuse.org/repositories/security:/zeek/](http://download.opensuse.org/repositories/security:/zeek/) I have bumped it to 20.04

* Use of `--no-cache` with pip3 install to prevent caching of packages will reduce the size of the Docker image
* Size got reduced significantly :
```
REPOSITORY     TAG       IMAGE ID       CREATED          SIZE
ubuntu-slips   latest    6046adad54f5   10 seconds ago   3.17GB
<none>         <none>    424d1921c963   2 hours ago      3.74GB
```