### PR TITLE
issue #267, use termcolor library instead of hardcoding color ascii in slips.py 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ wheel
 flask
 tld
 tqdm
+termcolor

--- a/slips.py
+++ b/slips.py
@@ -46,6 +46,7 @@ from collections import OrderedDict
 from distutils.dir_util import copy_tree
 from daemon import Daemon
 from multiprocessing import Queue
+from termcolor import colored
 
 version = '1.0.2'
 
@@ -680,9 +681,7 @@ class Main:
         """
         returns the text in green
         """
-        GREEN_s = '\033[1;32;40m'
-        GREEN_e = '\033[00m'
-        return f'{GREEN_s}{txt}{GREEN_e}'
+        return colored(txt, "green", "on_black")
 
 
     def print_stopped_module(self, module):

--- a/slips_files/core/database/database.py
+++ b/slips_files/core/database/database.py
@@ -410,6 +410,14 @@ class Database(ProfilingFlowsDatabase, object):
         :param user_agent: dict containing user_agent, os_type , os_name and agent_name
         """
         self.r.hset(profileid, 'User-agent', user_agent)
+        
+        # To keep a history of the past user agents and not just store the last user agent in the db
+        if not self.r.exists('past_user_agents'):
+            self.r.hset(profileid, 'past_user_agents', json.dumps([user_agent]))
+        else:
+            user_agents = json.load(self.r.hget(profileid, 'past_user_agents'))
+            user_agents.append(user_agent)
+            self.r.hset(profileid, 'past_user_agents', json.dumb(user_agents))
 
     def add_software_to_profile(
         self, profileid, software, version_major, version_minor, uid

--- a/slips_files/core/outputProcess.py
+++ b/slips_files/core/outputProcess.py
@@ -26,6 +26,7 @@ from datetime import datetime
 import os
 import traceback
 from tqdm.auto import tqdm
+from termcolor import colored
 
 class OutputProcess(multiprocessing.Process):
     """
@@ -219,7 +220,7 @@ class OutputProcess(multiprocessing.Process):
         verbose_level, debug_level = int(level[0]), int(level[1])
         # if verbosity level is 3 make it red
         if debug_level == 3:
-            msg = f'\033[0;35;40m{msg}\033[00m'
+            msg = colored(msg, "magenta", "on_black")
 
         # There should be a level 0 that we never print. So its >, and not >=
         if ((


### PR DESCRIPTION
#267  used termcolor library instead of hardcoding color.