### PR TITLE
Changed the README file to run the expected behavior in macos Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ To build a Docker image of Slips for macOS follow the next steps:
     cd StratosphereLinuxIPS/
     
     # build the MacOS image from the recommended Dockerfile
-    docker build --no-cache -t slips -f docker/macos-image/Dockerfile .
+    docker build --no-cache -t slips -f docker/macosm1-image/Dockerfile .
 ```
 
 To use Slips with files already inside the Docker you can do;


### PR DESCRIPTION
Refactored the documentation in README file which instructs to use `docker/macos-image/Dockerfile` to `docker/macosm1-image/Dockerfile` which is a valid path to the docker file.
Issue: #272 