### PR TITLE
0.0.0.0 and 255.255.255.255 are not set as private_ip

### DIFF
--- a/modules/flowalerts/set_evidence.py
+++ b/modules/flowalerts/set_evidence.py
@@ -344,6 +344,11 @@ class Helper:
     def set_evidence_conn_to_private_ip(
             self, daddr, dport, saddr, profileid, twid, uid, timestamp
     ):
+        
+        if (daddr == '0.0.0.0' or daddr == '255.255.255.255'):
+            return
+        if (saddr == '0.0.0.0' or saddr == '255.255.255.255'):
+            return
 
         confidence = 1
         threat_level = 'info'


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

Closes #256 

## Changes proposed

Change in set_evidence_conn_to_private_ip() function in modules/flowalerts/set_evidence.py which doesn't set evidence to IP 0.0.0.0 and 255.255.255.255.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
*Tests*:
![image](https://user-images.githubusercontent.com/32770175/229312071-64d4de32-4f8a-4272-8c76-bc448213cfaa.png)
![214142](https://user-images.githubusercontent.com/32770175/229312393-ebb83619-7ae8-4899-a67f-c1688b4953b4.png)
![44426](https://user-images.githubusercontent.com/32770175/229312409-e576dc4f-0b4e-46b4-a5e6-e79aa9c952a5.png)

