### PR TITLE
keep history of rnn-cc-module

### DIFF
--- a/config/slips.conf
+++ b/config/slips.conf
@@ -379,3 +379,10 @@ create_p2p_logfile = no
 
 # use_p2p = yes
 use_p2p = no
+
+####################
+# [11] configuration for rnn-cc-detection module
+[rnn-cc-detection]
+
+# path to where rnn info should be stored
+export_strato_letters = modules/rnn-cc-detection/rnn_info.csv

--- a/modules/rnn-cc-detection/rnn-cc-detection.py
+++ b/modules/rnn-cc-detection/rnn-cc-detection.py
@@ -53,16 +53,25 @@ class Module(Module, multiprocessing.Process):
         file = self.info_file.split('/')[-1]
         filepath = current_path + '/' + file
 
+        if symbol[0] in '123456789': periodicity = -1
+        if symbol[0] in 'abcdefghi': periodicity = 1
+        if symbol[0] in 'ABCDEFGHI': periodicity = 2
+        if symbol[0] in 'rstuvwxyz': periodicity = 3
+        if symbol[0] in 'RSTUVWXYZ': periodicity = 4
+
         if os.path.exists(filepath):
             with open(filepath, 'a') as csvfile:
                 csvwriter = csv.writer(csvfile)
-                csvwriter.writerow([symbol, senderaddr, destinationaddr, port, protocol, timenow, model_score])
+                csvwriter.writerow(
+                    [symbol, periodicity, senderaddr, destinationaddr, port, protocol, timenow, model_score])
         else:
             with open(filepath, 'w') as csvfile:
                 csvwriter = csv.writer(csvfile)
                 csvwriter.writerow(
-                    ['symbol', 'senderaddr', 'destinationaddr', 'port', 'protocol', 'time', 'model_score'])
-                csvwriter.writerow([symbol, senderaddr, destinationaddr, port, protocol, timenow, model_score])
+                    ['symbol', 'periodicity', 'senderaddr', 'destinationaddr', 'port', 'protocol', 'time',
+                     'model_score'])
+                csvwriter.writerow(
+                    [symbol, periodicity, senderaddr, destinationaddr, port, protocol, timenow, model_score])
 
     def set_evidence(
             self,

--- a/slips_files/common/config_parser.py
+++ b/slips_files/common/config_parser.py
@@ -508,6 +508,11 @@ class ConfigParser(object):
             'flowmldetection', 'mode', 'test'
         )
 
+    def get_rnn_file(self):
+        return self.read_configuration(
+            'rnn-cc-detection', 'export_strato_letters', 'modules/rnn-cc-detection/rnn_info.csv'
+        )
+
     def RiskIQ_credentials_path(self):
         return self.read_configuration(
             'threatintelligence', 'RiskIQ_credentials_path', ''
@@ -718,7 +723,6 @@ class ConfigParser(object):
             to_ignore.append('leak_detector')
 
         return to_ignore
-
 
 
 


### PR DESCRIPTION
## Fixes Issue
Closes #198 

## Changes proposed
Add feature to store rnn-cc module history. the flow data is stored in a csv file in the module/rnn-cc-detection directory. The csv has features symbol, periodicity, senderaddr, destinationaddr, port, protocol, time, model_score.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
![Screenshot from 2023-04-21 17-34-36](https://user-images.githubusercontent.com/75977159/233631171-0474163d-3f62-4e40-86c5-4fbc72c5bc46.png)



## Note to reviewers

<!-- Add notes to reviewers if applicable -->
