### PR TITLE
Update IP_info to use either 'ip neigh show' or 'arp -an' to obtain Gateway MAC

### DIFF
--- a/modules/ip_info/ip_info.py
+++ b/modules/ip_info/ip_info.py
@@ -455,7 +455,7 @@ class Module(Module, multiprocessing.Process):
                                       capture_output=True, check=True, text=True).stdout
             gw_MAC = ip_output.split()[-2]
             __database__.set_default_gateway('MAC', gw_MAC)
-            self.print(f"Gateway ({gw_ip}) MAC Address found using ip neigh show: {gw_MAC} ", 1, 0)
+            self.print(f"Gateway ({gw_ip}) MAC Address found using ip neigh show: {gw_MAC} ", 2, 0)
             return gw_MAC
         except (subprocess.CalledProcessError, FileNotFoundError):
             # If the ip command doesn't exist or has failed, try using the arp command
@@ -468,7 +468,7 @@ class Module(Module, multiprocessing.Process):
                     if len(fields) >= 2 and fields[1].strip('()') == gw_ip and len(fields[1].strip('()')) == len(gw_ip):
                         gw_MAC = fields[-4]
                         __database__.set_default_gateway('MAC', gw_MAC)
-                        self.print(f"Gateway ({gw_ip}) MAC Address found using arp -an: {gw_MAC} ", 1, 0)
+                        self.print(f"Gateway ({gw_ip}) MAC Address found using arp -an: {gw_MAC} ", 2, 0)
                         return gw_MAC
                         break 
             except (subprocess.CalledProcessError, FileNotFoundError):

--- a/modules/ip_info/ip_info.py
+++ b/modules/ip_info/ip_info.py
@@ -453,25 +453,22 @@ class Module(Module, multiprocessing.Process):
                                       capture_output=True, check=True, text=True).stdout
             gw_MAC = ip_output.split()[-2]
             __database__.set_default_gateway('MAC', gw_MAC)
-            self.print(f"Gateway ({gw_ip}) MAC Address found using ip neigh show: {gw_MAC} ", 2, 0)
             return gw_MAC
         except (subprocess.CalledProcessError, FileNotFoundError):
             # If the ip command doesn't exist or has failed, try using the arp command
             try:
-                arp_output = subprocess.run(["arp", "-an"], 
+                arp_output = subprocess.run(["arp", "-an"],
                                            capture_output=True, check=True, text=True).stdout
                 for line in arp_output.split('\n'):
                     fields = line.split()
-                    # Match the gw_ip in the output and compare the length
-                    if len(fields) >= 2 and fields[1].strip('()') == gw_ip and len(fields[1].strip('()')) == len(gw_ip):
+                    gw_ip_from_arp_cmd = fields[1].strip('()')
+                    # Match the gw_ip in the output with the one given to this function
+                    if len(fields) >= 2 and gw_ip_from_arp_cmd == gw_ip:
                         gw_MAC = fields[-4]
                         __database__.set_default_gateway('MAC', gw_MAC)
-                        self.print(f"Gateway ({gw_ip}) MAC Address found using arp -an: {gw_MAC} ", 2, 0)
                         return gw_MAC
-                        break 
             except (subprocess.CalledProcessError, FileNotFoundError):
                 # Could not find the MAC address of gw_ip
-                self.print(f"Cannot find the MAC address of the gateway ({gw_ip}). Please ensure either 'ip neigh show' or 'arp -an' commands work ", 0, 1 )
                 return
 
         return gw_MAC

--- a/modules/ip_info/ip_info.py
+++ b/modules/ip_info/ip_info.py
@@ -20,8 +20,6 @@ import re
 import time
 import asyncio
 
-import shutil
-
 
 class Module(Module, multiprocessing.Process):
     # Name: short name of the module. Do not use spaces


### PR DESCRIPTION
## Fixes Issue

Closes #332

## Changes proposed

Update modules/ip_info/ip_info.py, get_gateway_MAC method to use either 'ip neigh show' or 'arp -an' to obtain the MAC address for the gateway IP address from the hosts ARP table. 

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

![Screenshot 2023-05-17 8 41 00 PM](https://github.com/stratosphereips/StratosphereLinuxIPS/assets/13009494/91146f64-6a30-462a-a863-8330ed151261)


## Note to reviewers

A single integration test had failed prior to this change and continued after making the change.

```
FAILED tests/integration_tests/test_dataset.py::test_pcap[dataset/test7-malicious.pcap-15-test7/-A device changing IPs-6666] 
...
E       AssertionError: assert False is True
E        +  where False = is_evidence_present('output/integration_tests/test7/alerts.log', 'A device changing IPs')
```

First pull request, ever. Be gentle :) 

Thank you.