### PR TITLE
Fix-broadcast-address-matching

### DIFF
--- a/managers/process_manager.py
+++ b/managers/process_manager.py
@@ -416,7 +416,7 @@ class ProcessManager:
             # close all tws
             self.main.db.check_TW_to_close(close_all=True)
             analysis_time = self.get_analysis_time()
-            self.main.print(f"\nAnalysis of {self.main.input_information} "
+            self.main.print(f"Analysis of {self.main.input_information} "
                             f"finished in {analysis_time:.2f} minutes")
             flows_count: int = self.main.db.get_flows_count()
             self.main.print(f"Total flows read (without altflows): {flows_count}", log_to_logfiles_only=True)

--- a/modules/CESNET/CESNET.py
+++ b/modules/CESNET/CESNET.py
@@ -8,6 +8,7 @@ import threading
 import queue
 import ipaddress
 import validators
+from slips_files.common.slips_utils import utils
 
 
 class CESNET(IModule, multiprocessing.Process):
@@ -65,13 +66,13 @@ class CESNET(IModule, multiprocessing.Process):
 
                     if ip_version == 'IP4' and (
                         validators.ipv4(ip)
-                        and ipaddress.IPv4Address(ip).is_private
+                        and utils.is_private_ip(ipaddress.IPv4Address(ip))
                     ):
                         # private ipv4
                         evidence_in_IDEA[type_].remove(dict_)
                     elif (
                         validators.ipv6(ip)
-                        and ipaddress.IPv6Address(ip).is_private
+                        and utils.is_private_ip(ipaddress.IPv6Address(ip))
                     ):
                         # private ipv6
                         evidence_in_IDEA[type_].remove(dict_)

--- a/modules/flowalerts/flowalerts.py
+++ b/modules/flowalerts/flowalerts.py
@@ -15,6 +15,7 @@ import validators
 import collections
 import math
 import time
+from slips_files.common.slips_utils import utils
 
 
 class FlowAlerts(IModule, multiprocessing.Process):
@@ -138,8 +139,8 @@ class FlowAlerts(IModule, multiprocessing.Process):
 
         # make sure the 2 ips are private
         if not (
-                ipaddress.ip_address(saddr).is_private
-                and ipaddress.ip_address(daddr).is_private
+                utils.is_private_ip(ipaddress.ip_address(saddr))
+                and utils.is_private_ip(ipaddress.ip_address(daddr))
         ):
             return
 
@@ -1669,7 +1670,7 @@ class FlowAlerts(IModule, multiprocessing.Process):
             # any msg is published in the new_flow channel
             return
 
-        if not (validators.ipv4(ip_to_check) and ip_obj.is_private):
+        if not (validators.ipv4(ip_to_check) and utils.is_private_ip(ip_obj)):
             return
 
         # if it's a private ipv4 addr, it should belong to our local network
@@ -1716,7 +1717,7 @@ class FlowAlerts(IModule, multiprocessing.Process):
 
         if not (
                 validators.ipv4(saddr)
-                and ipaddress.ip_address(saddr).is_private
+                and utils.is_private_ip(ipaddress.ip_address(saddr))
         ):
             return
 

--- a/modules/ip_info/ip_info.py
+++ b/modules/ip_info/ip_info.py
@@ -15,6 +15,7 @@ import subprocess
 import re
 import time
 import asyncio
+from slips_files.common.slips_utils import utils
 
 
 class IPInfo(IModule, multiprocessing.Process):
@@ -196,7 +197,7 @@ class IPInfo(IModule, multiprocessing.Process):
         """
         if not hasattr(self, 'country_db'):
             return False
-        if ipaddress.ip_address(ip).is_private:
+        if utils.is_private_ip(ipaddress.ip_address(ip)):
             # Try to find if it is a local/private IP
             data = {'geocountry': 'Private'}
         elif geoinfo := self.country_db.get(ip):

--- a/modules/threat_intelligence/threat_intelligence.py
+++ b/modules/threat_intelligence/threat_intelligence.py
@@ -11,6 +11,7 @@ import dns
 import requests
 import threading
 import time
+from slips_files.common.slips_utils import utils
 
 
 class ThreatIntel(IModule, multiprocessing.Process, URLhaus):
@@ -338,7 +339,7 @@ class ThreatIntel(IModule, multiprocessing.Process, URLhaus):
                     ip_obj = ipaddress.ip_address(net_addr)
                     if (
                         ip_obj.is_multicast
-                        or ip_obj.is_private
+                        or utils.is_private_ip(ip_obj)
                         or ip_obj.is_link_local
                         or net_addr in utils.home_networks
                     ):

--- a/modules/update_manager/update_manager.py
+++ b/modules/update_manager/update_manager.py
@@ -13,6 +13,7 @@ import requests
 import sys
 import asyncio
 import datetime
+from slips_files.common.slips_utils import utils
 
 
 class UpdateManager(IModule, multiprocessing.Process):
@@ -1229,7 +1230,7 @@ class UpdateManager(IModule, multiprocessing.Process):
                         # make sure we're not blacklisting a private ip
                         ip_obj = ipaddress.ip_address(data)
                         if (
-                            ip_obj.is_private
+                            utils.is_private_ip(ip_obj)
                             or ip_obj.is_multicast
                             or ip_obj.is_link_local
                         ):
@@ -1299,7 +1300,7 @@ class UpdateManager(IModule, multiprocessing.Process):
                         ip_obj = ipaddress.ip_address(net_addr)
                         if (
                             ip_obj.is_multicast
-                            or ip_obj.is_private
+                            or utils.is_private_ip(ip_obj)
                             or ip_obj.is_link_local
                             or net_addr in utils.home_networks
                         ):

--- a/modules/virustotal/virustotal.py
+++ b/modules/virustotal/virustotal.py
@@ -9,6 +9,7 @@ import time
 import ipaddress
 import threading
 import validators
+from slips_files.common.slips_utils import utils
 
 
 class VT(IModule, multiprocessing.Process):
@@ -253,7 +254,7 @@ class VT(IModule, multiprocessing.Process):
 
         try:
             addr = ipaddress.ip_address(ip)
-            if addr.is_private:
+            if utils.is_private_ip(addr):
                 self.print(f'[{ip}] is private, skipping', 0, 2)
                 scores = 0, 0, 0, 0
                 return scores, '', ''
@@ -541,7 +542,7 @@ class VT(IModule, multiprocessing.Process):
             if (
                 'VirusTotal' not in cached_data
                 and not ip_addr.is_multicast
-                and not ip_addr.is_private
+                and not utils.is_private_ip(ip_addr)
             ):
                 self.set_vt_data_in_IPInfo(ip, cached_data)
 

--- a/slips_files/common/slips_utils.py
+++ b/slips_files/common/slips_utils.py
@@ -321,6 +321,19 @@ class Utils(object):
     def convert_to_mb(self, bytes):
         return int(bytes)/(10**6)
 
+    def is_private_ip(self, ip_obj:ipaddress) -> bool:
+        """
+        This function replaces the ipaddress library 'is_private'
+        because it does not work correctly and it does not ignore
+        the ips 0.0.0.0 or 255.255.255.255
+        """
+        # Is it a well-formed ipv4 or ipv6?
+        r_value = False
+        if ip_obj and ip_obj.is_private:
+            if ip_obj != ipaddress.ip_address('0.0.0.0') and ip_obj != ipaddress.ip_address('255.255.255.255'):
+                r_value = True
+        return r_value
+
     def is_ignored_ip(self, ip) -> bool:
         """
         This function checks if an IP is a special list of IPs that
@@ -333,7 +346,7 @@ class Utils(object):
         return bool(
             (
                 ip_obj.is_multicast
-                or ip_obj.is_private
+                or self.is_private_ip(ip_obj)
                 or ip_obj.is_link_local
                 or ip_obj.is_reserved
                 or '.255' in ip_obj.exploded

--- a/slips_files/core/database/redis_db/database.py
+++ b/slips_files/core/database/redis_db/database.py
@@ -530,6 +530,8 @@ class RedisDB(IoCHandler, AlertHandler, ProfileHandler, IObservable):
 
     def set_local_network(self, saddr):
         # set the local network used in the db
+        # For now the local network is only ipv4, but it could be ipv6 in the future. Todo.
+
         if self.is_localnet_set:
             return
 
@@ -538,7 +540,7 @@ class RedisDB(IoCHandler, AlertHandler, ProfileHandler, IObservable):
 
         if not (
                 validators.ipv4(saddr)
-                and ipaddress.ip_address(saddr).is_private
+                and utils.is_private_ip(ipaddress.ip_address(saddr))
         ):
             return
         # get the local network of this saddr
@@ -944,7 +946,7 @@ class RedisDB(IoCHandler, AlertHandler, ProfileHandler, IObservable):
 
         # since we don't have a mac gw in the db, see eif this given mac is the gw mac
         ip_obj = ipaddress.ip_address(ip)
-        if not ip_obj.is_private:
+        if not utils.is_private_ip(ip_obj):
             # now we're given a public ip and a MAC that's supposedly belongs to it
             # we are sure this is the gw mac
             # set it if we don't already have it in the db

--- a/slips_files/core/output.py
+++ b/slips_files/core/output.py
@@ -178,7 +178,7 @@ class Output(IObserver):
 
         self.errors_logfile_lock.acquire()
         with open(self.errors_logfile, 'a') as errors_logfile:
-            errors_logfile.write(f'{date_time} {msg["from"]}{msg["txt"]}\n')
+            errors_logfile.write(f'{date_time} [{msg["from"]}] {msg["txt"]}\n')
         self.errors_logfile_lock.release()
 
     def has_pbar(self):

--- a/tests/common_test_utils.py
+++ b/tests/common_test_utils.py
@@ -69,7 +69,6 @@ def check_error_keywords(line):
     error_keywords = ('<class', 'error', 'Error', 'Traceback')
     for keyword in error_keywords:
         if keyword in line:
-            print(f"@@@@@@@@@@@@@@@@ error : {keyword} is found.. line: {line} !!")
             return True
     return False
 

--- a/tests/common_test_utils.py
+++ b/tests/common_test_utils.py
@@ -69,7 +69,11 @@ def has_errors(output_dir):
     error_keywords = ('<class', 'error', 'Error', 'Traceback')
     # these are keywords that we ignore when found in slips.log or errors.log because
     # connection errors shouldn't fail the integration tests
-    ignored_error_keywords = ('Connection error', 'while downloading', 'Error while reading the TI file')
+    ignored_error_keywords = ('Connection error',
+                              'while downloading',
+                              'Error while reading the TI file',
+                              'Error parsing feed'
+                              )
 
     # we can't redirect stderr to a file and check it because we catch all exceptions in slips
     for file in error_files:

--- a/tests/common_test_utils.py
+++ b/tests/common_test_utils.py
@@ -66,17 +66,22 @@ def has_errors(output_dir):
     error_files = ('slips_output.txt', 'errors.log')
     error_files = [os.path.join(output_dir, file) for file in error_files]
 
+    error_keywords = ('<class', 'error', 'Error', 'Traceback')
+    # these are keywords that we ignore when found in slips.log or errors.log because
+    # connection errors shouldn't fail the integration tests
+    ignored_error_keywords = ('Connection error', 'while downloading', 'Error while reading the TI file')
+
     # we can't redirect stderr to a file and check it because we catch all exceptions in slips
     for file in error_files:
         with open(file, 'r') as f:
             for line in f:
-                if '<class' in line or 'error' in line or 'Error' in line or 'Traceback' in line:
-                    # connection errors shouldn't fail the integration tests
-                    if (
-                            'Connection error' in line
-                            or 'while downloading' in line
-                    ):
-                        continue
-                    return True
+                for ignored_keyword in ignored_error_keywords:
+                   if ignored_keyword in line:
+                       continue
+
+
+                for keyword in error_keywords:
+                    if keyword in line:
+                        return True
 
     return False


### PR DESCRIPTION
## Fixes Issue

Closes #322

## Changes proposed
Added function is_private_ip() to the file slips_files/common/slips_utils.py
This new function should replace the ipaddress.is_private function from now on, since the ipaddress.is_private function does not take into account the ip 0.0.0.0 and 255.255.255.255 as NOT private.

I also updated the rest of the files in Slips to use this new version.
- database.py
- virustotal.py
- update_manager.py
- threat_intelligence.py
- ip_info.py
- flow_alerts.py
- cestnet.py


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Note to reviewers

I cound not run the pytest, so I will let the unit test in github.