### PR TITLE
Fixed macos p2p docker image

### DIFF
--- a/docker/macosm1-P2P-image/requirements-macos-m1-docker.txt
+++ b/docker/macosm1-P2P-image/requirements-macos-m1-docker.txt
@@ -23,7 +23,7 @@ pytest-mock
 pytest-xdist
 slackclient
 scipy
-sklearn
+scikit-learn
 GitPython
 protobuf
 blinker


### PR DESCRIPTION
## Description
Replaced the `sklearn` with `scikit-learn`. 

## Fixes Issue
Closes #467 

## Changes proposed

Removed the `sklearn` from [macosm1-P2P-image/requirements-macos-m1-docker.txt](https://github.com/stratosphereips/StratosphereLinuxIPS/blob/a6b9f7113c84e017eaebacb0d567b5af414fbc1e/docker/macosm1-P2P-image/requirements-macos-m1-docker.txt) as it is deprecated and. Replaced `sklearn` with `scikit-learn` to keep it consistent with [macosm1-image/requirements-macos-m1-docker.txt](https://github.com/stratosphereips/StratosphereLinuxIPS/blob/a6b9f7113c84e017eaebacb0d567b5af414fbc1e/docker/macosm1-image/requirements-macos-m1-docker.txt)
