### PR TITLE
Improve the docker creation for macos M1

### DIFF
--- a/docker/macosm1-P2P-image/Dockerfile
+++ b/docker/macosm1-P2P-image/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && ln -s /opt/zeek/bin/zeek /usr/local/bin/bro
 
 
-RUN git clone -b m1-p2p-improve https://github.com/stratosphereips/StratosphereLinuxIPS ${SLIPS_DIR}/
+RUN git clone -b master https://github.com/stratosphereips/StratosphereLinuxIPS ${SLIPS_DIR}/
 WORKDIR ${SLIPS_DIR}
 RUN git submodule sync && git pull --recurse-submodules
 # Switch to Slips installation dir when login.

--- a/docker/macosm1-P2P-image/Dockerfile
+++ b/docker/macosm1-P2P-image/Dockerfile
@@ -56,7 +56,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 
 RUN git clone -b master https://github.com/stratosphereips/StratosphereLinuxIPS ${SLIPS_DIR}/
-RUN (cd ${SLIPS_DIR} && chmod 774 slips.py)
+
+WORKDIR ${SLIPS_DIR}
+RUN git submodule sync && git pull --recurse-submodules
+# Switch to Slips installation dir when login.
+RUN chmod 774 slips.py &&  git submodule init && git submodule update
 
 # Change the configuration file to have use_p2p = yes
 RUN sed -i "s/use_p2p = no/use_p2p = yes/g" ${SLIPS_DIR}/config/slips.conf
@@ -78,4 +82,5 @@ RUN npm install
 WORKDIR ${SLIPS_DIR}
 
 #CMD redis-server --daemonize yes && /bin/bash
-CMD /bin/bash
+CMD redis-server --daemonize yes && /bin/bash
+#CMD /bin/bash

--- a/docker/macosm1-P2P-image/Dockerfile
+++ b/docker/macosm1-P2P-image/Dockerfile
@@ -52,11 +52,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     iputils-ping \
     yara \
     tmux \
+    golang \
  && ln -s /opt/zeek/bin/zeek /usr/local/bin/bro
 
 
-RUN git clone -b master https://github.com/stratosphereips/StratosphereLinuxIPS ${SLIPS_DIR}/
-
+RUN git clone -b m1-p2p-improve https://github.com/stratosphereips/StratosphereLinuxIPS ${SLIPS_DIR}/
 WORKDIR ${SLIPS_DIR}
 RUN git submodule sync && git pull --recurse-submodules
 # Switch to Slips installation dir when login.
@@ -64,9 +64,15 @@ RUN chmod 774 slips.py &&  git submodule init && git submodule update
 
 # Change the configuration file to have use_p2p = yes
 RUN sed -i "s/use_p2p = no/use_p2p = yes/g" ${SLIPS_DIR}/config/slips.conf
-# Change the configuration file to have analysis_direction = out
-RUN sed -i "s/analysis_direction = out/analysis_direction = yes/g" ${SLIPS_DIR}/config/slips.conf
 
+# Change the configuration file to have analysis_direction = out
+RUN sed -i "s/analysis_direction = out/analysis_direction = all/g" ${SLIPS_DIR}/config/slips.conf
+
+# build the pigeon and Add pigeon to path
+SHELL ["/bin/bash", "-c"]
+RUN cd p2p4slips && go build && echo "export PATH=$PATH:/StratosphereLinuxIPS/p2p4slips/" >> ~/.bashrc && source ~/.bashrc
+
+WORKDIR ${SLIPS_DIR}
 # Upgrade pip3 and install slips requirements
 RUN pip3 install --upgrade pip
 RUN pip3 install -r ${SLIPS_DIR}/docker/macosm1-P2P-image/requirements-macos-m1-docker.txt
@@ -80,7 +86,4 @@ RUN npm install
 
 # Switch to Slips installation dir when login.
 WORKDIR ${SLIPS_DIR}
-
-#CMD redis-server --daemonize yes && /bin/bash
 CMD redis-server --daemonize yes && /bin/bash
-#CMD /bin/bash

--- a/docker/macosm1-P2P-image/requirements-macos-m1-docker.txt
+++ b/docker/macosm1-P2P-image/requirements-macos-m1-docker.txt
@@ -8,6 +8,7 @@ tzlocal
 cabby
 stix2
 certifi
+tensorflow
 colorama
 Keras
 validators
@@ -41,4 +42,3 @@ yappi
 pytest-sugar
 memray
 aid_hash
-tensorflow


### PR DESCRIPTION
The docker for p2p in macos M1 was not working correctly. This solves the problem

## Fixes Issue
The p2p library of slips was not correctly downloaded and executed

## Changes proposed

[x] - Modify the Dockerfile for macos-m1-p2p to correctly install programs, download the p2p library and execute it

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
