### PR TITLE
Fix typo and tell_pbar

### DIFF
--- a/slips/main.py
+++ b/slips/main.py
@@ -537,6 +537,7 @@ class Main(IObservable):
         profiles_len = self.db.get_profiles_len()
         evidence_number = self.db.get_evidence_number() or 0
         msg = (
+            f"[Main] "
             f"Total analyzed IPs so far: "
             f"{green(profiles_len)}. "
             f"Evidence Added: {green(evidence_number)}. "

--- a/slips_files/core/output.py
+++ b/slips_files/core/output.py
@@ -266,6 +266,8 @@ class Output(IObserver):
         writes to the pbar pipe. anything sent by this method
         will be received by the pbar class
         """
+        if not msg:
+            return
         self.pbar_sender_pipe.send(msg)
 
     def is_pbar_finished(self) -> bool:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -410,7 +410,7 @@ def test_tell_pbar_empty_message():
     msg = {}
     output.tell_pbar(msg)
 
-    output.pbar_sender_pipe.send.assert_called_once_with(msg)
+    output.pbar_sender_pipe.send.assert_not_called()
 
 
 def test_tell_pbar_none_message():
@@ -421,7 +421,7 @@ def test_tell_pbar_none_message():
     msg = None
     output.tell_pbar(msg)
 
-    output.pbar_sender_pipe.send.assert_called_once_with(msg)
+    output.pbar_sender_pipe.send.assert_not_called()
 
 
 def test_tell_pbar_large_message():


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

#871 
#879

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

Check if msg is empty or not before calling pbar_sender_pipe()

**Typo in main screen**
"[Main] " overwrote the first few character("Total A"). Adding [Main] is a simple fix but not permenant. I believe more analysis is required to understanding the reason of overwriting.
 Also the whole statement is printed once after "Flow Processed" line, but then disappears. Careful observation is required to notice this. 

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] All new and existing tests passed.
- [ X] This PR does not contain plagiarized content.
- [ X] The title of my pull request is a short description of the requested changes.

## Screenshots
![image](https://github.com/user-attachments/assets/a10eecb0-5e42-4453-9024-60c809eac060)


![image](https://github.com/user-attachments/assets/0ad9a762-f4a1-4f5b-afda-8957133f96db)


<!-- Add all the screenshots which support your changes -->

<!-- Add screenshots with the passing unit and integration tests locally -->

## Note to reviewers
Included in change proposed. 
<!-- Add notes to reviewers if applicable -->
