### PR TITLE
Fix problem with slips freezing in large PCAPs

### DIFF
--- a/managers/process_manager.py
+++ b/managers/process_manager.py
@@ -96,11 +96,7 @@ class ProcessManager:
         ):
             return False
 
-        if (
-            self.main.args.growing
-            or self.main.args.input_module
-            or self.main.args.testing
-        ):
+        if self.main.args.growing or self.main.args.input_module:
             return False
 
         return True
@@ -307,7 +303,6 @@ class ProcessManager:
                 )
                 print(traceback.format_exc())
                 failed_to_load_modules += 1
-
                 continue
 
             # Walk through all members of currently imported modules.

--- a/modules/progress_bar/progress_bar.py
+++ b/modules/progress_bar/progress_bar.py
@@ -38,6 +38,7 @@ class PBar(IModule):
         pbar_finished: Event = None,
     ):
         self.slips_mode: str = slips_mode
+        # the sender end of this pipe is at output.py
         self.pipe = pipe
         self.done_reading_flows = False
         self.pbar_finished: Event = pbar_finished
@@ -86,18 +87,6 @@ class PBar(IModule):
             return
 
         self.progress_bar.update(1)
-        if self.progress_bar.n == self.total_flows:
-            self.terminate()
-
-    def terminate(self):
-        # remove it from the bar because we'll be
-        # prining it in a new line
-        self.remove_stats()
-        tqdm.write(
-            "Profiler is done reading all flows. "
-            "Slips is now processing them."
-        )
-        self.pbar_finished.set()
 
     def print_to_cli(self, msg: dict):
         """
@@ -109,8 +98,25 @@ class PBar(IModule):
         """writes the stats sent in the msg as a pbar postfix"""
         self.progress_bar.set_postfix_str(msg["stats"], refresh=True)
 
+    def should_stop(self) -> bool:
+        """
+        overrides IModule.should_stop()
+        Returns true if the pbar reached 100%
+        """
+        if hasattr(self, "progress_bar"):
+            return self.progress_bar.n == self.total_flows
+        return False
+
     def shutdown_gracefully(self):
-        # to tell output.py to no longer send prints here
+        # remove it from the bar because output.py will be handling it from
+        # now on
+        self.remove_stats()
+        tqdm.write(
+            "Profiler is done reading all flows. "
+            "Slips is now processing them."
+        )
+        # the purpose of this pbar_finished Event is to tell output.py to no
+        # longer forward msgs to print here
         self.pbar_finished.set()
 
     def main(self):

--- a/modules/threat_intelligence/threat_intelligence.py
+++ b/modules/threat_intelligence/threat_intelligence.py
@@ -1540,15 +1540,8 @@ class ThreatIntel(IModule, URLhaus):
         the provided domain name and determines if it is considered malicious.
         """
         # Search for this domain in our database of IoC
-        (
-            domain_info,
-            is_subdomain,
-        ) = self.db.is_blacklisted_domain(domain)
-        if (
-            domain_info is not False
-        ):  # Dont change this condition. This is the only way it works
-            # If the domain is in the blacklist of IoC. Set an evidence
-            domain_info = json.loads(domain_info)
+        domain_info, is_subdomain = self.db.is_blacklisted_domain(domain)
+        if domain_info:
             return domain_info, is_subdomain
         return False, False
 

--- a/modules/threat_intelligence/threat_intelligence.py
+++ b/modules/threat_intelligence/threat_intelligence.py
@@ -1540,6 +1540,8 @@ class ThreatIntel(IModule, URLhaus):
         the provided domain name and determines if it is considered malicious.
         """
         # Search for this domain in our database of IoC
+        domain_info: Dict[str, str]
+        is_subdomain: bool
         domain_info, is_subdomain = self.db.is_blacklisted_domain(domain)
         if domain_info:
             return domain_info, is_subdomain

--- a/slips_files/core/database/redis_db/ioc_handler.py
+++ b/slips_files/core/database/redis_db/ioc_handler.py
@@ -248,29 +248,28 @@ class IoCHandler:
             self.constants.IOC_DOMAINS, domain
         )
         is_subdomain = False
-        if domain_description is None:
-            # try to match subdomain
-            ioc_domains: Dict[str, Dict[str, str]] = self.rcache.hgetall(
-                self.constants.IOC_DOMAINS
-            )
-            for malicious_domain, domain_info in ioc_domains.items():
-                malicious_domain: str
-                domain_info: str
-                # something like this
-                # {"description": "['hack''malware''phishing']",
-                # "source": "OCD-Datalake-russia-ukraine_IOCs-ALL.csv",
-                # "threat_level": "medium",
-                # "tags": ["Russia-UkraineIoCs"]}
-                domain_info: Dict[str, str] = json.loads(domain_info)
-                #  if the we contacted images.google.com and we have
-                #  google.com in our blacklists, we find a match
-                if malicious_domain in domain:
-                    is_subdomain = True
-                    return domain_info, is_subdomain
+        if domain_description:
+            return json.loads(domain_description), is_subdomain
 
-            return False, is_subdomain
-        else:
-            return domain_description, is_subdomain
+        # try to match subdomain
+        ioc_domains: Dict[str, Dict[str, str]] = self.rcache.hgetall(
+            self.constants.IOC_DOMAINS
+        )
+        for malicious_domain, domain_info in ioc_domains.items():
+            malicious_domain: str
+            domain_info: str
+            # something like this
+            # {"description": "['hack''malware''phishing']",
+            # "source": "OCD-Datalake-russia-ukraine_IOCs-ALL.csv",
+            # "threat_level": "medium",
+            # "tags": ["Russia-UkraineIoCs"]}
+            domain_info: Dict[str, str] = json.loads(domain_info)
+            #  if the we contacted images.google.com and we have
+            #  google.com in our blacklists, we find a match
+            if malicious_domain in domain:
+                is_subdomain = True
+                return domain_info, is_subdomain
+        return False, is_subdomain
 
     def get_all_blacklisted_ip_ranges(self) -> dict:
         """

--- a/slips_files/core/input.py
+++ b/slips_files/core/input.py
@@ -774,9 +774,10 @@ class Input(ICore):
             self.close_all_handles()
 
         if hasattr(self, "zeek_pid"):
-            # kill zeek manually if it started bc it's detached from this process and will never recv the sigint
-            # also withoutt this, inputproc will never shutdown and will always remain in memory causing 1000 bugs in
-            # proc_man:shutdown_gracefully()
+            # kill zeek manually if it started bc it's detached from this
+            # process and will never recv the sigint also withoutt this,
+            # inputproc will never shutdown and will always remain in memory
+            # causing 1000 bugs in proc_man:shutdown_gracefully()
             try:
                 os.kill(self.zeek_pid, signal.SIGKILL)
             except Exception:

--- a/slips_files/core/input_profilers/zeek.py
+++ b/slips_files/core/input_profilers/zeek.py
@@ -456,7 +456,6 @@ class ZeekTabs(IInputType):
                 get_value_at(15),  # scanned_port
                 get_value_at(13, "-"),  # scanning_ip
                 get_value_at(14),  # dst
-                type_="notice",
             )
         elif "files.log" in new_line["type"]:
             self.flow: Files = Files(

--- a/slips_files/core/output.py
+++ b/slips_files/core/output.py
@@ -149,18 +149,19 @@ class Output(IObserver):
         """
         self.cli_lock.acquire()
         try:
-            # when the pbar reaches 100% aka we're done_reading_flows
-            # we print alerts at the very botttom of the screen using print
-            # instead of printing alerts at the top of the pbar using tqdm
             if sender:
                 to_print = f"[{sender}] {txt}"
             else:
                 to_print = txt
 
+            # when the pbar reaches 100% aka we're is_pbar_finished() == True
+            # we print alerts at the very bottom of the screen using print
+            # instead of printing alerts at the top of the pbar using tqdm
             if self.has_pbar and not self.is_pbar_finished():
                 self.tell_pbar({"event": "print", "txt": to_print})
             else:
                 print(to_print, end=end)
+
         except Exception as e:
             print(f"Problem printing {txt}. {e}")
 
@@ -246,13 +247,20 @@ class Output(IObserver):
         self.pbar_sender_pipe.send(msg)
 
     def is_pbar_finished(self) -> bool:
+        """checks the pbar_finished event set by the pbar module"""
         return self.pbar_finished.is_set()
 
-    def forward_progress_bar_msgs(self, msg: dict):
+    def forward_progress_bar_msgs(self, msg: dict) -> bool:
         """
-        passes init and update msgs to pbar module
+        forwards 'init' and 'update' msgs to pbar module
+        pbar "print" msgs don't reach this function
+        returns true if the msg was sucessfuly forwarded to pbar process
         """
-        pbar_event: str = msg["bar"]
+        try:
+            pbar_event: str = msg["bar"]
+        except KeyError:
+            return False
+
         if pbar_event == "init":
             self.tell_pbar(
                 {
@@ -260,7 +268,7 @@ class Output(IObserver):
                     "total_flows": msg["bar_info"]["total_flows"],
                 }
             )
-            return
+            return True
 
         if pbar_event == "update" and not self.is_pbar_finished():
             self.tell_pbar(
@@ -268,11 +276,14 @@ class Output(IObserver):
                     "event": "update_bar",
                 }
             )
+            return True
+        return False
 
     def update(self, msg: dict):
         """
-        gets called whenever any module need to print something
-        each msg shhould be in the following format
+        is called whenever any module need to print something using the
+        Printer.notify_observers()
+        each msg should be in the following format
         {
             bar: 'update' or 'init'
             log_to_logfiles_only: bool that indicates wheteher we
@@ -286,9 +297,8 @@ class Output(IObserver):
                 total_flows: int,
         }
         """
-        # if pbar wasn't supported, inputproc won't send update msgs
-
-        # try:
+        # if pbar wasn't supported, profiler.py won't send update msgs
+        # the only process that sends msgs here is profiler.py
         if "bar" in msg:
             self.forward_progress_bar_msgs(msg)
             return
@@ -299,8 +309,3 @@ class Output(IObserver):
         else:
             # output to terminal
             self.output_line(msg)
-
-
-#         except Exception as e:
-#             print(f"Error in output.py: {e} {type(e)}")
-#             traceback.print_stack()

--- a/slips_files/core/profiler.py
+++ b/slips_files/core/profiler.py
@@ -479,15 +479,23 @@ class Profiler(ICore, IObservable):
                 self.input = SUPPORTED_INPUT_TYPES[self.input_type]()
 
             # get the correct input type class and process the line based on it
-            self.flow = self.input.process_line(line)
-            if self.flow:
-                self.add_flow_to_profile()
-                self.handle_setting_local_net()
+            try:
+                self.flow = self.input.process_line(line)
+                if self.flow:
+                    self.add_flow_to_profile()
+                    self.handle_setting_local_net()
 
-            # now that one flow is processed tell output.py
-            # to update the bar
-            if self.has_pbar:
-                self.notify_observers({"bar": "update"})
+                # now that one flow is processed tell output.py
+                # to update the bar
+                if self.has_pbar:
+                    self.notify_observers({"bar": "update"})
+            except Exception as e:
+                self.print(
+                    f"Problem processing line {line}. " f"Line discarded. {e}",
+                    0,
+                    1,
+                )
+                self.flow = False
 
             # listen on this channel in case whitelist.conf is changed,
             # we need to process the new changes

--- a/tests/test_inputProc.py
+++ b/tests/test_inputProc.py
@@ -54,8 +54,8 @@ def test_read_zeek_folder(zeek_dir: str, is_tabs: bool):
         os.path.join(zeek_dir, "conn.log")
     ]
     input.db.is_growing_zeek_dir.return_value = False
-    input.is_done_processing = Mock()
-    input.is_done_processing.return_value = True
+    input.mark_process_as_done_processing = Mock()
+    input.mark_process_as_done_processing.return_value = True
     input.start_observer = Mock()
     input.start_observer.return_value = True
     assert input.read_zeek_folder() is True

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -394,11 +394,11 @@ def test_check_for_stop_msg(monkeypatch):
     profiler = ModuleFactory().create_profiler_obj()
     monkeypatch.setattr(profiler, "shutdown_gracefully", Mock())
     monkeypatch.setattr(profiler, "is_done_processing", Mock())
-    assert profiler.check_for_stop_msg("stop") is True
+    assert profiler.is_stop_msg("stop") is True
     profiler.shutdown_gracefully.assert_called_once()
-    profiler.is_done_processing.assert_called_once()
+    profiler.mark_process_as_done_processing.assert_called_once()
 
-    assert profiler.check_for_stop_msg("not_stop") is False
+    assert profiler.is_stop_msg("not_stop") is False
 
 
 def test_pre_main(monkeypatch):
@@ -438,7 +438,7 @@ def test_is_done_processing(monkeypatch):
 
     monkeypatch.setattr(profiler, "print", mock_print)
 
-    profiler.is_done_processing()
+    profiler.mark_process_as_done_processing()
 
     profiler.done_processing.release.assert_called_once()
     profiler.is_profiler_done_event.set.assert_called_once()

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -415,7 +415,7 @@ def test_main_stop_msg_received():
     profiler.should_stop = Mock(side_effect=[False, True])
 
     profiler.profiler_queue = Mock(spec=queue.Queue)
-    profiler.profiler_queue.get.return_value = ["stop"]
+    profiler.profiler_queue.get.return_value = "stop"
 
     stopped = profiler.main()
     assert stopped

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -392,12 +392,7 @@ def test_should_set_localnet_already_set():
 
 def test_check_for_stop_msg(monkeypatch):
     profiler = ModuleFactory().create_profiler_obj()
-    monkeypatch.setattr(profiler, "shutdown_gracefully", Mock())
-    monkeypatch.setattr(profiler, "is_done_processing", Mock())
     assert profiler.is_stop_msg("stop") is True
-    profiler.shutdown_gracefully.assert_called_once()
-    profiler.mark_process_as_done_processing.assert_called_once()
-
     assert profiler.is_stop_msg("not_stop") is False
 
 
@@ -431,7 +426,7 @@ def mock_print(*args, **kwargs):
     pass
 
 
-def test_is_done_processing(monkeypatch):
+def test_mark_process_as_done_processing(monkeypatch):
     profiler = ModuleFactory().create_profiler_obj()
     profiler.done_processing = Mock()
     profiler.is_profiler_done_event = Mock()
@@ -558,12 +553,16 @@ def test_handle_in_flows_valid_daddr():
 
 def test_shutdown_gracefully(monkeypatch):
     profiler = ModuleFactory().create_profiler_obj()
+    profiler.print = Mock()
+    profiler.mark_process_as_done_processing = Mock()
     profiler.rec_lines = 100
-    monkeypatch.setattr(profiler, "print", Mock())
+
+    # monkeypatch.setattr(profiler, "print", Mock())
     profiler.shutdown_gracefully()
     profiler.print.assert_called_with(
         "Stopping. Total lines read: 100", log_to_logfiles_only=True
     )
+    profiler.mark_process_as_done_processing.assert_called_once()
 
 
 def test_init_pbar():

--- a/tests/test_progress_bar.py
+++ b/tests/test_progress_bar.py
@@ -42,7 +42,6 @@ def test_update_bar_termination():
     pbar.slips_mode = "normal"
     pbar.total_flows = 100
     pbar.pbar_finished = Event()
-
     mock_progress_bar = Mock()
     mock_progress_bar.n = 99
     pbar.progress_bar = mock_progress_bar
@@ -52,12 +51,10 @@ def test_update_bar_termination():
 
     mock_progress_bar.update.side_effect = update_side_effect
 
-    with patch.object(pbar, "terminate") as mock_terminate:
-        pbar.update_bar()
+    pbar.update_bar()
 
-        assert mock_progress_bar.update.call_count == 1
-        assert mock_progress_bar.n == 100
-        mock_terminate.assert_called_once()
+    assert mock_progress_bar.update.call_count == 1
+    assert mock_progress_bar.n == 100
 
 
 def test_update_bar_no_progress_bar():
@@ -140,20 +137,18 @@ def test_update_stats(
 
 def test_shutdown_gracefully_event_not_set():
     pbar = ModuleFactory().create_progress_bar_obj()
+    pbar.progress_bar = Mock()
     pbar.pbar_finished = Event()
-
     pbar.shutdown_gracefully()
-
     assert pbar.pbar_finished.is_set()
 
 
 def test_shutdown_gracefully_event_already_set():
     pbar = ModuleFactory().create_progress_bar_obj()
+    pbar.progress_bar = Mock()
     pbar.pbar_finished = Event()
     pbar.pbar_finished.set()
-
     pbar.shutdown_gracefully()
-
     assert pbar.pbar_finished.is_set()
 
 
@@ -182,7 +177,7 @@ def test_remove_stats():
         (1000000, 1000000),
     ],
 )
-def test_terminate(
+def test_shutdown_gracefully(
     total_flows,
     current_n,
 ):
@@ -197,7 +192,7 @@ def test_terminate(
     with patch.object(pbar, "remove_stats") as mock_remove_stats, patch(
         "tqdm.auto.tqdm.write"
     ) as mock_write:
-        pbar.terminate()
+        pbar.shutdown_gracefully()
 
         mock_remove_stats.assert_called_once()
         mock_write.assert_called_once_with(

--- a/tests/test_threat_intelligence.py
+++ b/tests/test_threat_intelligence.py
@@ -942,10 +942,10 @@ def test_search_online_for_url(
     [
         (
             "example.com",
-            ('{"description": "Malicious domain"}', False),
+            ({"description": "Malicious domain"}, False),
             ({"description": "Malicious domain"}, False),
         ),
-        ("safe.com", ("{}", False), ({}, False)),
+        ("safe.com", ({}, False), (False, False)),
     ],
 )
 def test_search_offline_for_domain(
@@ -1072,13 +1072,11 @@ def test_should_lookup(ip, protocol, ip_state, expected_result):
     [
         (
             "evil.com",
-            json.dumps(
-                {"description": "Malicious domain", "source": "test_source"}
-            ),
+            {"description": "Malicious domain", "source": "test_source"},
             None,
         ),
-        ("safe.com", json.dumps({}), False),
-        ("safe.com", "false", False),
+        ("safe.com", {}, False),
+        ("safe.com", False, False),
     ],
 )
 def test_is_malicious_cname(


### PR DESCRIPTION
- PBar was stopping as soon as it recieves the termination event, even if pbar didn't reach 100%, causing slips to stop printing and appear as frozen as in #953 
- in this PR, pbar is fixed to use its own should_stop() that only stops the process when the pbar reaches 100%, instead of the comon should_stop() at IModule