### PR TITLE
Optimize MAC OUIs and malicious domains lookups

### DIFF
--- a/modules/threat_intelligence/threat_intelligence.py
+++ b/modules/threat_intelligence/threat_intelligence.py
@@ -1429,16 +1429,6 @@ class ThreatIntel(IModule, URLhaus, Spamhaus):
         """Determines if a URL is considered malicious by querying online threat
         intelligence sources.
 
-        Parameters:
-            - url (str): The URL to check.
-            - uid (str): Unique identifier for the network flow.
-            - timestamp (str): Timestamp when the network flow occurred.
-            - daddr (str): Destination IP address in the network flow.
-            - profileid (str): Identifier of the profile associated
-            with the network flow.
-            - twid (str): Time window identifier for when the network
-            flow occurred.
-
         Returns:
             - None: The function does not return a value but triggers
             evidence creation if the URL is found to be malicious.
@@ -1632,18 +1622,6 @@ class ThreatIntel(IModule, URLhaus, Spamhaus):
         identified as
         malicious, it records an evidence entry and marks the
         domain in the database.
-
-        Parameters:
-            domain (str): The domain name to be evaluated for
-             malicious activity.
-            uid (str): Unique identifier of the network flow
-            associated with this domain query.
-            timestamp (str): Timestamp when the domain query
-            was observed.
-            profileid (str): Identifier of the network profile
-            that initiated the domain query.
-            twid (str): Time window identifier during which the
-            domain query occurred.
 
         Returns:
             bool: False if the domain is ignored or not found in the

--- a/slips_files/common/data_structures/trie.py
+++ b/slips_files/common/data_structures/trie.py
@@ -1,0 +1,47 @@
+from collections import defaultdict
+from typing import (
+    Dict,
+    Tuple,
+    Optional,
+)
+
+
+class TrieNode:
+    def __init__(self):
+        self.children = defaultdict(TrieNode)
+        self.is_end_of_word = False
+        self.domain_info = (
+            None  # store associated domain information if needed
+        )
+
+
+class Trie:
+    def __init__(self):
+        self.root = TrieNode()
+
+    def insert(self, domain: str, domain_info: str):
+        """Insert a domain into the trie (using domain parts not chars)."""
+        node = self.root
+        parts = domain.split(".")[::-1]  # reverse to handle subdomains
+        for part in parts:
+            node = node.children[part]
+        node.is_end_of_word = True
+        node.domain_info = domain_info
+
+    def search(self, domain: str) -> Tuple[bool, Optional[Dict[str, str]]]:
+        """
+        Check if a domain or its subdomain exists in the trie
+         (using domain parts instead of characters).
+        Returns a tuple (found, domain_info).
+        """
+        node = self.root
+        # reverse domain to handle subdomains
+        parts = domain.split(".")[::-1]
+        for part in parts:
+            if part not in node.children:
+                return False, None
+
+            node = node.children[part]
+            if node.is_end_of_word:
+                return True, node.domain_info
+        return False, None

--- a/slips_files/core/database/redis_db/database.py
+++ b/slips_files/core/database/redis_db/database.py
@@ -131,6 +131,8 @@ class RedisDB(IoCHandler, AlertHandler, ProfileHandler):
                 )
 
             cls._instances[cls.redis_port] = super().__new__(cls)
+            super().__init__(cls)
+
             # By default the slips internal time is
             # 0 until we receive something
             cls.set_slips_internal_time(0)


### PR DESCRIPTION
- use lru cache for mac lookups
- use trie data structure for storing and looking up malicious domains. (100x speedup). closes #1014 