### PR TITLE
Readme.md file updated 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Redis >= 7.0.4 for interprocess communication.
 The recommended way to use Slips is on Docker.
 
 #### Linux and Windows hosts
+Do not use --net=host if you want to access the internal container's ports from the host.
 ```
 docker run --rm -it -p 55000:55000  --cpu-shares "700" --memory="8g" --memory-swap="8g" --net=host --cap-add=NET_ADMIN --name slips stratosphereips/slips:latest
 ```


### PR DESCRIPTION
updated linux hosts container use , as on linux also you do not use --net=host if you want to access the internal container's ports from the host.
While using --net=host:
![image](https://github.com/user-attachments/assets/496bfee7-1638-492c-a972-6ee66ba7a9a4)
Without using --net=host:
![image](https://github.com/user-attachments/assets/663434d5-151e-423d-adc2-7b0bec5f7c9c)

