### PR TITLE
Fixed syntax warning in main.py

### DIFF
--- a/slips/main.py
+++ b/slips/main.py
@@ -328,7 +328,7 @@ class Main:
 
                     # zeek tab files are separated by several spaces or tabs
                     sequential_spaces_found = re.search(
-                        "\s{1,}-\s{1,}", first_line
+                        r"\s{1,}-\s{1,}", first_line
                     )
                     tabs_found = re.search("\t{1,}", first_line)
                     commas_found = re.search(",{1,}", first_line)


### PR DESCRIPTION


Updated main.py with proper escape sequence in sequential_spaces_found line

## Fixes Issue  
#1152 



## Changes proposed


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

<!-- Add screenshots with the passing unit and integration tests locally -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
