### PR TITLE
ARP poisoner Improvements

### DIFF
--- a/managers/process_manager.py
+++ b/managers/process_manager.py
@@ -47,9 +47,7 @@ from slips_files.core.profiler import Profiler
 class ProcessManager:
     def __init__(self, main):
         self.main = main
-        # this will be set by main.py if slips is not daemonized,
-        # it'll be set to the children of main.py
-        self.processes: Dict[str, Process]
+
         # this is the queue that will be used by the input proces
         # to pass flows to the profiler
         self.profiler_queue = Queue()
@@ -76,6 +74,11 @@ class ProcessManager:
         # cant get more lines anymore!
         self.is_profiler_done_event = Event()
         self.read_config()
+
+    def set_slips_processes(self, children: Dict[str, Process]):
+        # this will be set by main.py if slips is not daemonized,
+        # it'll be set to the children of main.py
+        self.processes = children
 
     def read_config(self):
         self.modules_to_ignore: list = self.main.conf.get_disabled_modules(

--- a/managers/process_manager.py
+++ b/managers/process_manager.py
@@ -110,6 +110,7 @@ class ProcessManager:
             self.termination_event,
             self.main.args,
             self.main.conf,
+            self.main.pid,
             is_profiler_done=self.is_profiler_done,
             profiler_queue=self.profiler_queue,
             is_profiler_done_event=self.is_profiler_done_event,
@@ -132,6 +133,7 @@ class ProcessManager:
             self.evidence_handler_termination_event,
             self.main.args,
             self.main.conf,
+            self.main.pid,
         )
         evidence_process.start()
         self.main.print(
@@ -151,6 +153,7 @@ class ProcessManager:
             self.termination_event,
             self.main.args,
             self.main.conf,
+            self.main.pid,
             is_input_done=self.is_input_done,
             profiler_queue=self.profiler_queue,
             input_type=self.main.input_type,
@@ -260,7 +263,6 @@ class ProcessManager:
         """
         plugins = {}
         failed_to_load_modules = 0
-
         for module_name in self._discover_module_names():
             if not self._should_load_module(module_name):
                 continue
@@ -396,6 +398,7 @@ class ProcessManager:
                 self.termination_event,
                 self.main.args,
                 self.main.conf,
+                self.main.pid,
             )
             module.start()
             self.main.db.store_pid(module_name, int(module.pid))
@@ -452,6 +455,7 @@ class ProcessManager:
                     multiprocessing.Event(),
                     self.main.args,
                     self.main.conf,
+                    self.main.pid,
                 )
 
                 if local_files:

--- a/managers/profilers_manager.py
+++ b/managers/profilers_manager.py
@@ -82,7 +82,7 @@ class ProfilersManager:
                     subprocess.run(viz_args)
                     exit(0)
             else:
-                # reaching here means slips is now running using the vistracer
+                # reaching here means slips is now running using the viztracer
                 # command
                 self.cpu_profiler = CPUProfiler(
                     db=self.main.db,

--- a/managers/redis_manager.py
+++ b/managers/redis_manager.py
@@ -415,6 +415,8 @@ class RedisManager:
                 Output(),
                 self.main.args.output,
                 port,
+                None,  # doesnt matter here
+                None,  # doesnt matter here
                 start_sqlite=False,
                 start_redis_server=False,
             )

--- a/managers/redis_manager.py
+++ b/managers/redis_manager.py
@@ -415,8 +415,8 @@ class RedisManager:
                 Output(),
                 self.main.args.output,
                 port,
-                None,  # doesnt matter here
-                None,  # doesnt matter here
+                self.main.conf,
+                self.main.pid,
                 start_sqlite=False,
                 start_redis_server=False,
             )
@@ -555,5 +555,3 @@ class RedisManager:
                 self.remove_server_from_log(port)
             except (KeyError, ValueError):
                 print(f"Invalid input {server_to_close}")
-
-        self.main.terminate_slips()

--- a/modules/arp/arp.py
+++ b/modules/arp/arp.py
@@ -529,7 +529,7 @@ class ARP(IModule):
 
     def pre_main(self):
         """runs once before the main() is executed in a loop"""
-        utils.drop_root_privs()
+        utils.drop_root_privs_permanently()
         utils.start_thread(self.timer_thread_arp_scan, self.db)
 
     def main(self):

--- a/modules/arp/arp.py
+++ b/modules/arp/arp.py
@@ -88,7 +88,7 @@ class ARP(IModule):
     def wait_for_arp_scans(self):
         """
         This thread waits for 10s then checks if more
-        arp scans happened to reduce the number of alerts
+        arp scans happened to reduce the number of evidence
         """
         # this evidence is the one that triggered this thread
         scans_ctr = 0
@@ -317,7 +317,11 @@ class ARP(IModule):
                 timestamp=flow.starttime,
                 victim=victim,
             )
-            self.set_evidence(evidence)
+            # no need to go through the arp filter here, so use
+            # self.db.set_evidence instead of self.set_evidence
+            # because the filter is only to filter attacks that can be done
+            # using the arp_poisoner, but this one isnt done there.
+            self.db.set_evidence(evidence)
             return True
 
         return False

--- a/modules/arp_poisoner/arp_poisoner.py
+++ b/modules/arp_poisoner/arp_poisoner.py
@@ -114,8 +114,12 @@ class ARPPoisoner(IModule):
             return set()
 
         # --retry=0 to avoid redundant retries.
-        cmd = ["arp-scan", f"--interface={interface}", "--localnet"]
-
+        cmd = [
+            "arp-scan",
+            f"--interface={interface}",
+            "--localnet",
+            "--retry=0",
+        ]
         try:
             output = subprocess.check_output(cmd, text=True)
         except subprocess.CalledProcessError as e:

--- a/modules/cesnet/cesnet.py
+++ b/modules/cesnet/cesnet.py
@@ -247,7 +247,7 @@ class CESNET(IModule):
         self.db.add_ips_to_ioc(src_ips)
 
     def pre_main(self):
-        utils.drop_root_privs()
+        utils.drop_root_privs_permanently()
         # Stop module if the configuration file is invalid or not found
         if self.stop_module:
             return 1

--- a/modules/exporting_alerts/exporting_alerts.py
+++ b/modules/exporting_alerts/exporting_alerts.py
@@ -30,7 +30,7 @@ class ExportingAlerts(IModule):
         self.stix.shutdown_gracefully()
 
     def pre_main(self):
-        utils.drop_root_privs()
+        utils.drop_root_privs_permanently()
 
         export_to_slack = self.slack.should_export()
         export_to_stix = self.stix.should_export()

--- a/modules/fidesModule/fidesModule.py
+++ b/modules/fidesModule/fidesModule.py
@@ -184,7 +184,7 @@ class FidesModule(IModule):
          runs in a loop
         """
         self.__setup_trust_model()
-        utils.drop_root_privs()
+        utils.drop_root_privs_permanently()
 
     def main(self):
         if msg := self.get_msg("new_alert"):

--- a/modules/flowalerts/flowalerts.py
+++ b/modules/flowalerts/flowalerts.py
@@ -63,7 +63,7 @@ class FlowAlerts(AsyncModule):
         self.dns.shutdown_gracefully()
 
     def pre_main(self):
-        utils.drop_root_privs()
+        utils.drop_root_privs_permanently()
         self.dns.pre_analyze()
         self.analyzers_map = {
             "new_downloaded_file": [self.downloaded_file],

--- a/modules/flowmldetection/flowmldetection.py
+++ b/modules/flowmldetection/flowmldetection.py
@@ -416,7 +416,7 @@ class FlowMLDetection(IModule):
             self.store_model()
 
     def pre_main(self):
-        utils.drop_root_privs()
+        utils.drop_root_privs_permanently()
         # Load the model
         self.read_model()
 

--- a/modules/http_analyzer/http_analyzer.py
+++ b/modules/http_analyzer/http_analyzer.py
@@ -628,7 +628,7 @@ class HTTPAnalyzer(AsyncModule):
         await asyncio.gather(*self.tasks, return_exceptions=True)
 
     def pre_main(self):
-        utils.drop_root_privs()
+        utils.drop_root_privs_permanently()
 
     async def main(self):
         if msg := self.get_msg("new_http"):

--- a/modules/ip_info/ip_info.py
+++ b/modules/ip_info/ip_info.py
@@ -551,7 +551,7 @@ class IPInfo(AsyncModule):
         self.db.set_evidence(evidence)
 
     def pre_main(self):
-        utils.drop_root_privs()
+        utils.drop_root_privs_permanently()
         self.wait_for_dbs()
 
         self.is_running_in_ap_mode: bool = self.is_ap_mode_iwconfig()

--- a/modules/leak_detector/leak_detector.py
+++ b/modules/leak_detector/leak_detector.py
@@ -364,7 +364,7 @@ class LeakDetector(IModule):
                 )
 
     def pre_main(self):
-        utils.drop_root_privs()
+        utils.drop_root_privs_permanently()
 
         if not self.bin_found:
             # yara is not installed

--- a/modules/network_discovery/network_discovery.py
+++ b/modules/network_discovery/network_discovery.py
@@ -372,7 +372,7 @@ class NetworkDiscovery(IModule):
             )
 
     def pre_main(self):
-        utils.drop_root_privs()
+        utils.drop_root_privs_permanently()
 
     def main(self):
         if msg := self.get_msg("tw_modified"):

--- a/modules/p2ptrust/trust/trustdb.py
+++ b/modules/p2ptrust/trust/trustdb.py
@@ -16,6 +16,7 @@ class TrustDB(ISQLite):
         self,
         logger: Output,
         db_file: str,
+        main_pid: int,
         drop_tables_on_startup: bool = False,
     ):
         """create a database connection to a SQLite database"""
@@ -24,7 +25,7 @@ class TrustDB(ISQLite):
             db_file, check_same_thread=False, timeout=20
         )
         self.cursor = self.conn.cursor()
-        super().__init__(self.name.replace(" ", "_").lower())
+        super().__init__(self.name.replace(" ", "_").lower(), main_pid)
         if drop_tables_on_startup:
             self.print("Dropping tables")
             self.delete_tables()

--- a/modules/p2ptrust/trust/trustdb.py
+++ b/modules/p2ptrust/trust/trustdb.py
@@ -20,8 +20,10 @@ class TrustDB(ISQLite):
     ):
         """create a database connection to a SQLite database"""
         self.printer = Printer(logger, self.name)
-        self.connect(db_file)
-        super().__init__(self.name.replace(" ", "_").lower(), main_pid)
+        # connects to the db
+        super().__init__(
+            self.name.replace(" ", "_").lower(), main_pid, db_file
+        )
         if drop_tables_on_startup:
             self.print("Dropping tables")
             self.delete_tables()

--- a/modules/p2ptrust/trust/trustdb.py
+++ b/modules/p2ptrust/trust/trustdb.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2021 Sebastian Garcia <sebastian.garcia@agents.fel.cvut.cz>
 # SPDX-License-Identifier: GPL-2.0-only
-import sqlite3
 import datetime
 import time
 
@@ -21,10 +20,7 @@ class TrustDB(ISQLite):
     ):
         """create a database connection to a SQLite database"""
         self.printer = Printer(logger, self.name)
-        self.conn = sqlite3.connect(
-            db_file, check_same_thread=False, timeout=20
-        )
-        self.cursor = self.conn.cursor()
+        self.connect(db_file)
         super().__init__(self.name.replace(" ", "_").lower(), main_pid)
         if drop_tables_on_startup:
             self.print("Dropping tables")

--- a/modules/riskiq/riskiq.py
+++ b/modules/riskiq/riskiq.py
@@ -85,7 +85,7 @@ class RiskIQ(IModule):
         return sorted_pt_results
 
     def pre_main(self):
-        utils.drop_root_privs()
+        utils.drop_root_privs_permanently()
         if not self.riskiq_email or not self.riskiq_key:
             return 1
 

--- a/modules/rnn_cc_detection/rnn_cc_detection.py
+++ b/modules/rnn_cc_detection/rnn_cc_detection.py
@@ -252,7 +252,7 @@ class CCDetection(IModule):
         self.exporter.export(profileid, twid)
 
     def pre_main(self):
-        utils.drop_root_privs()
+        utils.drop_root_privs_permanently()
         # TODO: set the decision threshold in the function call
         try:
             self.tcpmodel = load_model("modules/rnn_cc_detection/rnn_model.h5")

--- a/modules/template/template.py
+++ b/modules/template/template.py
@@ -39,7 +39,7 @@ class Template(IModule):
         """
         Initializations that run only once before the main() function runs in a loop
         """
-        utils.drop_root_privs()
+        utils.drop_root_privs_permanently()
 
     def main(self):
         """Main loop function"""

--- a/modules/threat_intelligence/threat_intelligence.py
+++ b/modules/threat_intelligence/threat_intelligence.py
@@ -1798,7 +1798,7 @@ class ThreatIntel(IModule, URLhaus, Spamhaus):
         return True
 
     def pre_main(self):
-        utils.drop_root_privs()
+        utils.drop_root_privs_permanently()
         # Load the local Threat Intelligence files that are
         # stored in the local folder self.path_to_local_ti_files
         # The remote files are being loaded by the update_manager

--- a/modules/timeline/timeline.py
+++ b/modules/timeline/timeline.py
@@ -333,7 +333,7 @@ class Timeline(IModule):
             return True
 
     def pre_main(self):
-        utils.drop_root_privs()
+        utils.drop_root_privs_permanently()
 
     def main(self):
         # Main loop function

--- a/modules/update_manager/update_manager.py
+++ b/modules/update_manager/update_manager.py
@@ -110,6 +110,11 @@ class UpdateManager(IModule):
         self.path_to_remote_ti_files = conf.remote_ti_data_path()
         if not os.path.exists(self.path_to_remote_ti_files):
             os.mkdir(self.path_to_remote_ti_files)
+            # make it accessible to root and non-root users, because when
+            # slips is started using sudo, it drops privs from modules that
+            # don't need them, and without this line, these modules wont be
+            # able to access the path_to_remote_ti_files
+            os.chmod(self.path_to_remote_ti_files, 0o777)
 
         self.ti_feeds_path = conf.ti_files()
         self.url_feeds = self.get_feed_details(self.ti_feeds_path)

--- a/modules/virustotal/virustotal.py
+++ b/modules/virustotal/virustotal.py
@@ -544,7 +544,7 @@ class VT(IModule):
         return url_ratio, down_file_ratio, ref_file_ratio, com_file_ratio
 
     def pre_main(self):
-        utils.drop_root_privs()
+        utils.drop_root_privs_permanently()
         if not self.read_api_key() or self.key in ("", None):
             # We don't have a virustotal key
             return 1

--- a/slips/daemon.py
+++ b/slips/daemon.py
@@ -312,6 +312,7 @@ class Daemon:
                     output_dir,
                     port,
                     self.slips.conf,
+                    self.slips.pid,
                     start_sqlite=False,
                     flush_db=False,
                 )

--- a/slips/main.py
+++ b/slips/main.py
@@ -7,6 +7,7 @@ import os
 import re
 import shutil
 import signal
+import stat
 import subprocess
 import sys
 import time
@@ -60,7 +61,7 @@ class Main:
             self.profilers_manager = ProfilersManager(self)
             self.pid = os.getpid()
             self.checker.check_given_flags()
-
+            self.prepare_locks_dir()
             if not self.args.stopdaemon:
                 # Check the type of input
                 (
@@ -452,6 +453,19 @@ class Main:
         if mac := self.db.get_gateway_mac():
             self.print(f"Detected gateway MAC: {green(mac)}")
         self.gw_info_printed = True
+
+    def prepare_locks_dir(self):
+        """
+        sets the correct permissions for the /tmp/slips directory to be
+        used by root and non-root users
+        """
+        locks_dir = utils.slips_locks_dir
+        # Create the directory if it doesn't exist
+        if not os.path.exists(locks_dir):
+            os.makedirs(locks_dir, exist_ok=True)
+
+        # Set permissions: 0777 (no sticky bit)
+        os.chmod(locks_dir, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)
 
     def start(self):
         """Main Slips Function"""

--- a/slips/main.py
+++ b/slips/main.py
@@ -464,8 +464,12 @@ class Main:
         # Create the directory if it doesn't exist
         if not os.path.exists(locks_dir):
             os.makedirs(locks_dir, exist_ok=True)
-
-        os.chmod(locks_dir, 0o777)  # World-writable, no sticky bit
+        try:
+            os.chmod(locks_dir, 0o777)  # World-writable, no sticky bit
+        except PermissionError:
+            # this dir was created by root, so we can't change the permissions
+            # but probably root has already set the permissions
+            pass
 
     def start(self):
         """Main Slips Function"""

--- a/slips/main.py
+++ b/slips/main.py
@@ -108,12 +108,12 @@ class Main:
     def terminate_slips(self):
         """
         Shutdown slips, is called when stopping slips before
-        starting all modules. for example using -cb
+        starting all modules. for example using -cb or -k
         """
         if self.mode == DAEMONIZED_MODE:
             self.daemon.stop()
         if not self.conf.get_cpu_profiler_enable():
-            sys.exit(0)
+            sys.exit(0)  # leaves any children started by slips as orphans
 
     def save_the_db(self):
         # save the db to the output dir of this analysis

--- a/slips/main.py
+++ b/slips/main.py
@@ -590,9 +590,9 @@ class Main:
             self.metadata_man.add_metadata_if_enabled()
 
             self.input_process = self.proc_man.start_input_process()
-
             # obtain the list of active processes
-            self.proc_man.processes = multiprocessing.active_children()
+            children = multiprocessing.active_children()
+            self.proc_man.set_slips_processes(children)
 
             self.db.store_pid("slips.py", int(self.pid))
             self.metadata_man.set_input_metadata()

--- a/slips_files/common/abstracts/imodule.py
+++ b/slips_files/common/abstracts/imodule.py
@@ -37,6 +37,7 @@ class IModule(ABC, Process):
         termination_event,
         slips_args,
         conf,
+        ppid: int,
         **kwargs,
     ):
         Process.__init__(self)
@@ -47,12 +48,14 @@ class IModule(ABC, Process):
         self.args: Namespace = slips_args
         # to be able to access the configuration file
         self.conf = conf
+        # the parent pid of this module, used for strating the db
+        self.ppid = ppid
         # used to tell all slips.py children to stop
         self.termination_event: Event = termination_event
         self.logger = logger
         self.printer = Printer(self.logger, self.name)
         self.db = DBManager(
-            self.logger, self.output_dir, self.redis_port, self.conf
+            self.logger, self.output_dir, self.redis_port, self.conf, self.ppid
         )
         self.keyboard_int_ctr = 0
         self.init(**kwargs)

--- a/slips_files/common/abstracts/isqlite.py
+++ b/slips_files/common/abstracts/isqlite.py
@@ -1,8 +1,11 @@
 import fcntl
+import os
 import sqlite3
 from abc import ABC
 from threading import Lock
 from time import sleep
+
+from slips_files.common.slips_utils import utils
 
 
 class ISQLite(ABC):
@@ -30,7 +33,14 @@ class ISQLite(ABC):
         # try to write to the same sqlite db at the same time
         # this name needs to change per sqlite db, meaning trustb should have
         # its own lock file that is different from slips' main sqlite db lockfile
-        self.lockfile_name = f"/tmp/slips_{name}.lock"
+        username = os.getenv("USER") or "unknown"
+        pid = os.getpid()
+        # we're using the username and pid to create a unique lock file per
+        # slips run, so that multiple instances of slips can run at the
+        # same time
+        self.lockfile_name = os.path.join(
+            utils.slips_locks_dir, f"{username}_{pid}_trust_db.lock"
+        )
         # important: do not use self.execute here because this query
         # shouldnt be wrapped in a transaction, which is what self.execute(
         # ) does

--- a/slips_files/common/slips_utils.py
+++ b/slips_files/common/slips_utils.py
@@ -59,6 +59,9 @@ class Utils(object):
             "high": 0.8,
             "critical": 1,
         }
+        # why are we not using /var/lock? bc we need it to be r/w/x by
+        # everyone
+        self.slips_locks_dir = "/tmp/slips"
         self.time_formats = (
             "%Y-%m-%dT%H:%M:%S.%f%z",
             "%Y-%m-%d %H:%M:%S.%f",

--- a/slips_files/common/slips_utils.py
+++ b/slips_files/common/slips_utils.py
@@ -432,8 +432,10 @@ class Utils(object):
     def to_delta(self, time_in_seconds):
         return timedelta(seconds=int(time_in_seconds))
 
-    def get_human_readable_datetime(self) -> str:
-        return utils.convert_ts_format(datetime.now(), self.alerts_format)
+    def get_human_readable_datetime(self, format=None) -> str:
+        return utils.convert_ts_format(
+            datetime.now(), format or self.alerts_format
+        )
 
     def get_mac_for_ip_using_cache(self, ip: str) -> str | None:
         """gets the mac of the given local ip using the local arp cache"""

--- a/slips_files/core/database/database_manager.py
+++ b/slips_files/core/database/database_manager.py
@@ -33,6 +33,7 @@ class DBManager:
         output_dir,
         redis_port,
         conf,
+        main_pid: int,
         start_sqlite=True,
         start_redis_server=True,
         **kwargs,
@@ -52,6 +53,7 @@ class DBManager:
             self.trust_db = TrustDB(
                 self.logger,
                 self.trust_db_path,
+                main_pid,
                 drop_tables_on_startup=False,
             )
 
@@ -60,7 +62,7 @@ class DBManager:
         # the existing one
         self.sqlite = None
         if start_sqlite:
-            self.sqlite = SQLiteDB(self.logger, output_dir)
+            self.sqlite = SQLiteDB(self.logger, output_dir, main_pid)
 
     def init_p2ptrust_db(self) -> str:
         """returns  the path of the trustdb inside the p2ptrust_runtime_dir"""

--- a/slips_files/core/database/database_manager.py
+++ b/slips_files/core/database/database_manager.py
@@ -22,7 +22,7 @@ class DBManager:
     """
     This class will be calling methods from the appropriate db.
     each method added to any of the dbs should have a
-    handler in here
+    handler in here.
     """
 
     name = "DBManager"

--- a/slips_files/core/database/sqlite_db/database.py
+++ b/slips_files/core/database/sqlite_db/database.py
@@ -33,10 +33,8 @@ class SQLiteDB(ISQLite):
             # init tables once we connect
             db_newly_created = True
             self._init_db()
-
-        self.connect(self._flows_db)
-
-        super().__init__(self.name.lower(), main_pid)
+        # connects to the db
+        super().__init__(self.name.lower(), main_pid, self._flows_db)
 
         if db_newly_created:
             # only init tables if the db is newly created

--- a/slips_files/core/database/sqlite_db/database.py
+++ b/slips_files/core/database/sqlite_db/database.py
@@ -34,25 +34,13 @@ class SQLiteDB(ISQLite):
             db_newly_created = True
             self._init_db()
 
-        self.connect()
+        self.connect(self._flows_db)
 
         super().__init__(self.name.lower(), main_pid)
 
         if db_newly_created:
             # only init tables if the db is newly created
             self.init_tables()
-
-    def connect(self):
-        """
-        Creates the db if it doesn't exist and connects to it.
-        OR connects to the existing db if it's there.
-        """
-        # you can get multithreaded access on a single pysqlite connection by
-        # passing "check_same_thread=False"
-        self.conn = sqlite3.connect(
-            self._flows_db, check_same_thread=False, timeout=20
-        )
-        self.cursor = self.conn.cursor()
 
     def init_tables(self):
         """creates the tables we're gonna use"""

--- a/slips_files/core/evidence_handler.py
+++ b/slips_files/core/evidence_handler.py
@@ -387,7 +387,9 @@ class EvidenceHandler(ICore):
         """
 
         self.db.set_alert(alert, evidence_causing_the_alert)
-        self.decide_blocking(alert.profile.ip, alert.timewindow)
+        is_blocked: bool = self.decide_blocking(
+            alert.profile.ip, alert.timewindow
+        )
         # like in the firewall
         profile_already_blocked: bool = self.db.is_blocked_profile_and_tw(
             str(alert.profile), str(alert.timewindow)
@@ -407,9 +409,6 @@ class EvidenceHandler(ICore):
         if self.popup_alerts:
             self.show_popup(alert)
 
-        is_blocked: bool = self.decide_blocking(
-            alert.profile.ip, alert.timewindow
-        )
         if is_blocked:
             self.db.mark_profile_and_timewindow_as_blocked(
                 str(alert.profile), str(alert.timewindow)

--- a/slips_files/core/evidence_handler.py
+++ b/slips_files/core/evidence_handler.py
@@ -92,7 +92,7 @@ class EvidenceHandler(ICore):
         utils.change_logfiles_ownership(self.logfile.name, self.UID, self.GID)
 
         self.is_running_non_stop = self.db.is_running_non_stop()
-        self.blocking_module_supported = self.is_blocking_modules_supported()
+        self.blocking_modules_supported = self.is_blocking_modules_supported()
 
         # clear output/alerts.json
         self.jsonfile = self.clean_file(self.output_dir, "alerts.json")
@@ -424,7 +424,7 @@ class EvidenceHandler(ICore):
          returns True if the given IP was blocked by Slips blocking module
         """
         # send ip to the blocking module
-        if not self.blocking_module_supported:
+        if not self.blocking_modules_supported:
             return False
         # now since this source ip(profileid) caused an alert,
         # it means it caused so many evidence(attacked others a lot)

--- a/slips_files/core/helpers/checker.py
+++ b/slips_files/core/helpers/checker.py
@@ -72,6 +72,7 @@ class Checker:
         if self.main.args.interface and self.main.args.filepath:
             print("Only -i or -f is allowed. Stopping slips.")
             self.main.terminate_slips()
+            return
 
         if (
             self.main.args.interface or self.main.args.filepath
@@ -80,16 +81,19 @@ class Checker:
                 "You can't use --input-module with -f or -i. Stopping slips."
             )
             self.main.terminate_slips()
+            return
 
         if (self.main.args.save or self.main.args.db) and os.getuid() != 0:
             print("Saving and loading the database requires root privileges.")
             self.main.terminate_slips()
+            return
 
         if (self.main.args.verbose and int(self.main.args.verbose) > 3) or (
             self.main.args.debug and int(self.main.args.debug) > 3
         ):
             print("Debug and verbose values range from 0 to 3.")
             self.main.terminate_slips()
+            return
 
         # Check if redis server running
         if (
@@ -98,6 +102,7 @@ class Checker:
         ):
             print("Redis database is not running. Stopping Slips")
             self.main.terminate_slips()
+            return
 
         if self.main.args.config and not os.path.exists(self.main.args.config):
             print(f"{self.main.args.config} doesn't exist. Stopping Slips")
@@ -108,6 +113,7 @@ class Checker:
                 "Warning: P2P is only supported using "
                 "an interface. P2P Disabled."
             )
+            return
 
         if self.main.conf.use_global_p2p() and not (
             self.main.args.interface or self.main.args.growing
@@ -116,6 +122,7 @@ class Checker:
                 "Warning: Global P2P (Fides Module + Iris Module) is only supported using "
                 "an interface. Global P2P (Fides Module + Iris Module) Disabled."
             )
+            return
 
         if self.main.args.interface:
             interfaces = psutil.net_if_addrs().keys()
@@ -125,6 +132,7 @@ class Checker:
                     f"Stopping Slips"
                 )
                 self.main.terminate_slips()
+                return
 
         # if we're reading flows from some module other than the input
         # process, make sure it exists
@@ -132,25 +140,31 @@ class Checker:
             self.main.args.input_module
         ):
             self.main.terminate_slips()
+            return
 
         # Clear cache if the parameter was included
         if self.main.args.clearcache:
             self.clear_redis_cache()
+            return
+
         # Clear cache if the parameter was included
         if self.main.args.blocking and not self.main.args.interface:
             print(
                 "Blocking is only allowed when running slips using an interface."
             )
             self.main.terminate_slips()
+            return
 
         # kill all open unused redis servers if the parameter was included
         if self.main.args.killall:
             self.main.redis_man.close_open_redis_servers()
             self.main.terminate_slips()
+            return
 
         if self.main.args.version:
             self.main.print_version()
             self.main.terminate_slips()
+            return
 
         if (
             self.main.args.interface
@@ -161,6 +175,7 @@ class Checker:
             # iptables
             print("Run Slips with sudo to use the blocking modules.")
             self.main.terminate_slips()
+            return
 
         if self.main.args.clearblocking:
             if os.geteuid() != 0:
@@ -171,11 +186,13 @@ class Checker:
             else:
                 self.delete_blocking_chain()
             self.main.terminate_slips()
+            return
 
         # Check if user want to save and load a db at the same time
         if self.main.args.save and self.main.args.db:
             print("Can't use -s and -d together")
             self.main.terminate_slips()
+            return
 
     def delete_blocking_chain(self):
         from modules.blocking.slips_chain_manager import (

--- a/slips_files/core/output.py
+++ b/slips_files/core/output.py
@@ -66,6 +66,10 @@ class Output(IObserver):
         # we just need an instance of this class to be able
         # to start the db from the daemon class
         if create_logfiles:
+            # to create worl-writable files, so that when a module drops
+            # root privs, it can still write to the logfiles created by
+            # root (if slips was started by root)
+            os.umask(0)
             self._read_configuration()
             self.create_logfile(self.errors_logfile)
             self.log_branch_info(self.errors_logfile)

--- a/tests/test_arp_poisoner.py
+++ b/tests/test_arp_poisoner.py
@@ -159,7 +159,7 @@ def test__arp_poison_uses_cache(poisoner):
         patch.object(poisoner, "_isolate_target_from_localnet") as iso,
         patch.object(poisoner, "log"),
     ):
-        poisoner._arp_poison("192.168.1.5", first_time=True)
+        poisoner._attack("192.168.1.5", first_time=True)
         cut.assert_called_once()
         iso.assert_called_once()
 
@@ -176,7 +176,7 @@ def test__arp_poison_fallback_to_arp(poisoner):
                 patch.object(poisoner, "_cut_targets_internet") as cut,
                 patch.object(poisoner, "_isolate_target_from_localnet") as iso,
             ):
-                poisoner._arp_poison("192.168.1.5")
+                poisoner._attack("192.168.1.5")
                 cut.assert_called_once()
                 iso.assert_called_once()
 
@@ -187,7 +187,7 @@ def test__arp_poison_fails(poisoner):
         return_value=None,
     ):
         with patch.object(poisoner, "_get_mac_using_arp", return_value=None):
-            assert poisoner._arp_poison("192.168.1.5") is None
+            assert poisoner._attack("192.168.1.5") is None
 
 
 @pytest.mark.parametrize("should_unblock", [False, True])

--- a/tests/test_evidence_handler.py
+++ b/tests/test_evidence_handler.py
@@ -35,7 +35,7 @@ def test_decide_blocking(
     profileid, our_ips, expected_result, expected_publish_call_count
 ):
     evidence_handler = ModuleFactory().create_evidence_handler_obj()
-    evidence_handler.blocking_module_supported = True
+    evidence_handler.blocking_modules_supported = True
     evidence_handler.our_ips = our_ips
     with patch.object(evidence_handler.db, "publish") as mock_publish:
         tw = TimeWindow(

--- a/tests/test_fides_module.py
+++ b/tests/test_fides_module.py
@@ -28,4 +28,4 @@ def test_pre_main(mocker, cleanup_database):
     fides_module = ModuleFactory().create_fidesModule_obj()
     mocker.patch("slips_files.common.slips_utils.Utils.drop_root_privs")
     fides_module.pre_main()
-    utils.drop_root_privs.assert_called_once()
+    utils.drop_root_privs_permanently.assert_called_once()

--- a/tests/test_http_analyzer.py
+++ b/tests/test_http_analyzer.py
@@ -454,7 +454,7 @@ def test_pre_main(mocker):
     http_analyzer = ModuleFactory().create_http_analyzer_obj()
     mocker.patch("slips_files.common.slips_utils.Utils.drop_root_privs")
     http_analyzer.pre_main()
-    utils.drop_root_privs.assert_called_once()
+    utils.drop_root_privs_permanently.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_slips_utils.py
+++ b/tests/test_slips_utils.py
@@ -525,7 +525,7 @@ def test_drop_root_privs(
 ):
     mock_getenv.side_effect = side_effect
     utils = ModuleFactory().create_utils_obj()
-    utils.drop_root_privs()
+    utils.drop_root_privs_permanently()
 
     assert mock_setresuid.call_args_list == setresuid_calls
     assert mock_setresgid.call_args_list == setresgid_calls


### PR DESCRIPTION
closes [#1274](https://github.com/stratosphereips/StratosphereLinuxIPS/issues/1274)

Improvements implemented:

- Adaptive delay between arp scans (min 30s max 120s depending on the local network)
- Cache arp scan results for a while instead of re-scanning when the network seems stable
- Reduce the amount of packets sent by Isolate the attacker and cutting the attackers internet every 30s mins instead of 10  
- generate fake MACs on the fly instead of using "aa:aa:aa:aa:aa:aa" to avoid anti spoofing protections in some OSes
- make sure the arp filter filters only attacks that can be done with ARP poisoner, not all ARP attacks.
- Never poison the gateway


This PR also includes several local P2P trustdb fixes 