### PR TITLE
Running on interface without ip address

### DIFF
--- a/managers/host_ip_manager.py
+++ b/managers/host_ip_manager.py
@@ -52,14 +52,19 @@ class HostIPManager:
         if not self.main.db.is_running_non_stop():
             return
 
-        if host_ip := self.get_host_ip():
-            self.main.db.set_host_ip(host_ip)
-            self.main.print(f"Detected host IP: {green(host_ip)}")
-            return host_ip
+        while 1:
+            host_ip = self.get_host_ip()
+            if host_ip:
+                self.main.db.set_host_ip(host_ip)
+                self.main.print(f"Detected host IP: {green(host_ip)}")
+                return host_ip
+            elif self.main.args.interface and not host_ip:
+                self.main.print("Running on interface without IP Address. Not setting host IP.")
+                return None 
+            else:
+                self.main.print("Not connected to the internet. Reconnecting in 10s.")
+                time.sleep(10)
 
-        self.main.print("Not Connected to the internet. Reconnecting in 10s.")
-        time.sleep(10)
-        self.store_host_ip()
 
     def update_host_ip(
         self, host_ip: str, modified_profiles: Set[str]


### PR DESCRIPTION
<!-- Add screenshots with the passing unit and integration tests locally -->

## Note to reviewers
Fixed the perpetual hang when capturing traffic on an interface without a configured IP address.

<!-- Add notes to reviewers if applicable -->
