### PR TITLE
fix problem of unknown port evidence still triggereing known ports due to case mistmach

### DIFF
--- a/modules/flowalerts/conn.py
+++ b/modules/flowalerts/conn.py
@@ -189,7 +189,8 @@ class Conn(IFlowalertsAnalyzer):
             # scanned from this attacker
             return False
 
-        portproto = f"{flow.dport}/{flow.proto}"
+        proto = str(flow.proto or "").lower()
+        portproto = f"{flow.dport}/{proto}"
         if self.db.get_port_info(portproto):
             # it's a known port
             return False
@@ -201,7 +202,7 @@ class Conn(IFlowalertsAnalyzer):
             return False
 
         if (
-            "icmp" not in flow.proto
+            "icmp" not in proto
             and not self.is_p2p(flow)
             and not self.db.is_ftp_port(flow.dport)
         ):

--- a/tests/unit/modules/flowalerts/test_conn.py
+++ b/tests/unit/modules/flowalerts/test_conn.py
@@ -205,6 +205,43 @@ def test_check_unknown_port_true_case(mocker):
     mock_set_evidence.assert_called_once_with(twid, flow)
 
 
+def test_check_unknown_port_uses_lowercase_protocol_for_known_ports(mocker):
+    conn = ModuleFactory().create_conn_analyzer_obj()
+    flow = Conn(
+        starttime="1726249372.312124",
+        uid="123",
+        saddr="192.168.1.1",
+        daddr="147.32.82.7",
+        dur=1,
+        proto="UDP",
+        appproto="",
+        sport="12345",
+        dport="53",
+        spkts=2,
+        dpkts=1,
+        sbytes=120,
+        dbytes=60,
+        smac="",
+        dmac="",
+        state="Established",
+        history="S",
+    )
+
+    flow.interpreted_state = "Established"
+    conn.db.is_a_port_scanner = Mock(return_value=False)
+    conn.db.get_port_info = Mock(return_value="DNS")
+    conn.db.is_ftp_port = Mock(return_value=False)
+    mocker.patch.object(conn, "port_belongs_to_an_org", return_value=False)
+    mocker.patch.object(conn, "is_p2p", return_value=False)
+    mock_set_evidence = mocker.patch.object(conn.set_evidence, "unknown_port")
+
+    profileid = f"profile_{flow.saddr}"
+
+    assert conn.check_unknown_port(profileid, twid, flow) is False
+    conn.db.get_port_info.assert_called_once_with("53/udp")
+    mock_set_evidence.assert_not_called()
+
+
 @pytest.mark.parametrize(
     "origstate, saddr, daddr, dport, uids, interpreted_state, expected_calls",
     [


### PR DESCRIPTION
## Fixes Issue
Some unknown ports are known and were put in evidences

`        - Detected Connection to unknown destination port 53/UDP destination IP 147.32.82.7. threat level: high.`


## Changes proposed
Fix the case error mistmach



## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
- [x] My PR is based on develop branch. (mandatory)
