### PR TITLE
Fix #1840: Exception when p2p is shutting down

### DIFF
--- a/modules/p2ptrust/p2ptrust.py
+++ b/modules/p2ptrust/p2ptrust.py
@@ -594,7 +594,7 @@ class Trust(IModule):
         self.db.publish("new_blame", data)
 
     def shutdown_gracefully(self):
-        if hasattr(self, "pigeon"):
+        if hasattr(self, "pigeon") and self.pigeon is not None:
             self.pigeon.send_signal(signal.SIGINT)
         if hasattr(self, "trust_db"):
             self.trust_db.__del__()

--- a/tests/unit/modules/p2ptrust/test_p2ptrust.py
+++ b/tests/unit/modules/p2ptrust/test_p2ptrust.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Garcia <sebastian.garcia@agents.fel.cvut.cz>
+# SPDX-License-Identifier: GPL-2.0-only
+import signal
+import sys
+import types
+from unittest.mock import MagicMock, patch
+import pytest
+
+# Stub out netifaces before any project import touches it
+if "netifaces" not in sys.modules:
+    sys.modules["netifaces"] = types.ModuleType("netifaces")
+
+
+class TestShutdownGracefully:
+    """Tests for Trust.shutdown_gracefully (issue #1840)."""
+
+    def _make_trust_instance(self):
+        """Return a bare Trust instance with only the attributes we need."""
+        from modules.p2ptrust.p2ptrust import Trust
+
+        # Build a minimal object without calling __init__
+        obj = object.__new__(Trust)
+        return obj
+
+    def test_shutdown_gracefully_pigeon_none_no_exception(self):
+        """shutdown_gracefully must not raise when self.pigeon is None."""
+        trust = self._make_trust_instance()
+        trust.pigeon = None  # mirrors the state set in _configure when binary missing
+
+        # Should complete without AttributeError
+        trust.shutdown_gracefully()
+
+    def test_shutdown_gracefully_pigeon_sends_sigint(self):
+        """shutdown_gracefully sends SIGINT when pigeon process is running."""
+        trust = self._make_trust_instance()
+        mock_pigeon = MagicMock()
+        trust.pigeon = mock_pigeon
+
+        trust.shutdown_gracefully()
+
+        mock_pigeon.send_signal.assert_called_once_with(signal.SIGINT)
+
+    def test_shutdown_gracefully_no_pigeon_attr(self):
+        """shutdown_gracefully must not raise when pigeon attribute is absent."""
+        trust = self._make_trust_instance()
+        # Do NOT set trust.pigeon at all
+
+        trust.shutdown_gracefully()


### PR DESCRIPTION
Closes #1840

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

Closes #1840

## Changes proposed

- **`modules/p2ptrust/p2ptrust.py`, `shutdown_gracefully()` (line 597):** Tightened the guard from `if hasattr(self, "pigeon")` to `if hasattr(self, "pigeon") and self.pigeon is not None`. When the pigeon binary is missing or `_configure()` sets `self.pigeon = None`, the previous check passed the `hasattr` test but immediately raised `AttributeError: 'NoneType' object has no attribute 'send_signal'` on the `send_signal` call.
- **`tests/unit/modules/p2ptrust/test_p2ptrust.py` (new file):** Adds three unit tests covering the three distinct states of `self.pigeon` at shutdown: attribute absent, attribute is `None`, and attribute holds a live mock process. The last case asserts `send_signal` is called with `signal.SIGINT`.

## Steps you followed to test the changes purposed in this PR:

* Reproduced the original crash by instantiating `Trust` with `self.pigeon = None` and calling `shutdown_gracefully()` — confirmed `AttributeError` before the fix.
* Applied the one-line fix and re-ran the same scenario — confirmed no exception is raised.
* Ran the new unit tests: `pytest tests/unit/modules/p2ptrust/test_p2ptrust.py -v` — all 3 tests passed.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
- [x] My PR is based on develop branch. (mandatory)

## Screenshots

N/A

## Note to reviewers

The root cause is that `_configure()` can explicitly assign `self.pigeon = None` when the pigeon subprocess fails to start, so `hasattr` alone is not a sufficient guard. The fix is minimal and surgical; no behaviour changes when `pigeon` is a live process.