### PR TITLE
Close the used redis servers after the analysis

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -54,7 +54,10 @@ jobs:
           python3 -m pytest tests/${{ matrix.test_file }} -p no:warnings -vv -s -n 3
 
       - name: Build Artifact Name
-        # otherwise we get numeric names for the artifacts and we dont know which is which
+        # built names, otherwise we get numeric names for the artifacts and we dont know which is which
+        # always() here because when the pytest step fails, GitHub skips the name-building step, so steps.artifact-name.outputs.name is empty
+        # and upload-artifact rejects it.
+        if: always()
         id: artifact-name
         run: |
           sanitized_test_file="${{ matrix.test_file }}"

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ terminal interface.
 
 ##### Web interface
 
-    ./webinterface.sh
+    ./slips.py -e 1 -f dataset/test7-malicious.pcap -o output_dir -w
 
 Then navigate to ```http://localhost:55000/``` from your browser.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,6 +109,17 @@ Redis allows all the modules in Slips to access the data in parallel.
 Apart from read and write operations, Slips takes advantage of the Redis messaging system called Redis PUB/SUB.
 Processes may publish data into the channels, while others subscribe to these channels and process the new data when it is published.
 
+When Slips uses a Redis port other than the default Redis port 6379,
+it closes the opened redis server when analysis is done, and keeps a
+copy of the Redis database for later analysis in
+`output_dir/databases/dump.rdb`. To inspect this database, start a Redis server
+with that RDB file and connect to the same port:
+
+```bash
+redis-server --port 6380 --dir output_dir/databases --dbfilename dump.rdb
+redis-cli -p 6380
+```
+
 ### Usage of SQLite database.
 
 Slips uses SQLite database to store all flows in Slips interpreted format.

--- a/docs/slips_in_action.md
+++ b/docs/slips_in_action.md
@@ -50,7 +50,7 @@ This explains the start and stop timestamps in the alert `start 2021-04-10T16:44
 
 The difference between infected and normal timewindows is shown better in the web interface.
 
-You can inspect the results in another terminal using `./webinterface.sh`
+Start Slips with `-w` to inspect the results in the web interface.
 
 <img src="https://raw.githubusercontent.com/stratosphereips/StratosphereLinuxIPS/develop/docs/images/web_interface.png" title="Slips web interface">
 <p> Figure 3 </p>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -173,6 +173,9 @@ When using the web interface, you can select among the active Redis-backed analy
     [2] dataset/test7-malicious.pcap - port 59324
 
 You can choose the corresponding file or interface from the web interface.
+You can also use the `Browse redis database` button in the web interface to
+load a saved `.rdb` file directly. The upload accepts only files with the
+`.rdb` extension.
 
 Once you're done, you can run slips with ```--killall``` to close all the redis servers using the following command
 
@@ -254,6 +257,11 @@ Then navigate to ```http://localhost:55000/``` from your browser.
 
 
 <img src="https://raw.githubusercontent.com/stratosphereips/StratosphereLinuxIPS/develop/docs/images/web_interface.png" width="850px" title="Web Interface">
+
+Use `Change DB` to switch between active Redis server. Use
+`Browse redis database` to upload and inspect a saved Redis `.rdb` file. If the
+file is not a Redis RDB file or Redis cannot load it, the web interface shows a
+warning and keeps the current database selected.
 
 On the right column, you can see a list of all the IPs seen in your traffic.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -299,9 +299,9 @@ Note: If you try to save the same file twice using ```-s``` the old backup will 
 
 You can load it again using ```-d```, For example:
 
-```sudo ./slips.py -d redis_backups/hide-and-seek-short.rdb ```
+```sudo ./slips.py -d redis_backups/hide-and-seek-short.rdb -w```
 
-And then use ```./webinterface.sh``` and select the entry on port 32850 to view the loaded database.
+Then navigate to ```http://localhost:55000/``` and select the entry on port 32850 to view the loaded database.
 
 Note: saving and loading the database requires **root privileges** and is only supported in linux.
 

--- a/managers/process_manager.py
+++ b/managers/process_manager.py
@@ -21,6 +21,7 @@ from multiprocessing.process import BaseProcess
 from typing import (
     List,
     Tuple,
+    Callable,
 )
 
 from exclusiveprocess import (
@@ -493,10 +494,6 @@ class ProcessManager:
                 return False
         else:
             if self.is_disabled_module(module_name):
-                print(
-                    f"@@@@@@@@@@@@@@@@ {module_name} is ignored in the "
-                    f"config? {self.slips_disabled_modules}"
-                )
                 return False
         return True
 
@@ -770,7 +767,7 @@ class ProcessManager:
 
         return alive_processes
 
-    def get_analysis_time(self) -> Tuple[str, str]:
+    def get_analysis_time(self) -> Tuple[float, str]:
         """
         Returns how long slips took to analyze the given file
         returns analysis_time in minutes and slips end_time as a date
@@ -1005,6 +1002,50 @@ class ProcessManager:
             self.plotter.write_throughput_metrics()
             self.plotter.plot_flows_from_conn_log()
 
+    def _print_shutdown_stats(
+        self,
+        graceful_shutdown: bool,
+        analysis_time: float,
+        reason: str,
+        print: Callable,
+    ) -> None:
+        """
+        Print the shutdown summary.
+
+        Parameters:
+            graceful_shutdown: Whether Slips finished without forcing modules.
+            analysis_time: Analysis duration in minutes.
+            reason: Explanation when shutdown was not graceful.
+            print: Print function for the current Slips mode.
+
+        Return value:
+            None.
+        """
+        print(
+            f"Analysis of {self.main.input_information} "
+            f"finished in {analysis_time:.2f} minutes"
+        )
+
+        if graceful_shutdown:
+            if self.is_slips_live_updating_event.is_set():
+                print(
+                    "[Process Manager] Slips is live updating, "
+                    "Stopping this instance and starting the new "
+                    "instance now.\n",
+                    log_to_logfiles_only=True,
+                )
+
+            print(
+                "[Process Manager] Slips shutdown gracefully\n",
+                log_to_logfiles_only=True,
+            )
+        else:
+            print(
+                f"[Process Manager] Slips didn't "
+                f"shutdown gracefully - {reason}\n",
+                log_to_logfiles_only=True,
+            )
+
     def shutdown_gracefully(self):
         """
         Waits for all modules to confirm that they're done processing
@@ -1037,6 +1078,7 @@ class ProcessManager:
                 self.main.db.check_tw_to_close(close_all=True)
 
             graceful_shutdown = True
+            reason = ""
             if self.main.mode == "daemonized":
                 self.kill_daemon_children()
                 profiles_len: int = self.main.db.get_profiles_len()
@@ -1099,6 +1141,8 @@ class ProcessManager:
             if not self.is_slips_live_updating_event.is_set():
                 if self.main.args.save:
                     self.main.save_the_db()
+                if self.main.redis_man.should_save_redis_db_after_analysis():
+                    self.main.redis_man.save_redis_db()
                 if self.main.conf.export_labeled_flows():
                     format_ = self.main.conf.export_labeled_flows_to().lower()
                     self.main.db.export_labeled_flows(format_)
@@ -1113,34 +1157,16 @@ class ProcessManager:
             analysis_time, end_date = self.get_analysis_time()
             self.main.metadata_man.set_analysis_end_date(end_date)
 
-            print(
-                f"Analysis of {self.main.input_information} "
-                f"finished in {analysis_time:.2f} minutes"
-            )
-
             self.main.profilers_manager.cpu_profiler_release()
             self.main.profilers_manager.memory_profiler_release()
 
             self.main.db.close_all_dbs()
-            if graceful_shutdown:
-                if self.is_slips_live_updating_event.is_set():
-                    print(
-                        "[Process Manager] Slips is live updating, "
-                        "Stopping this instance and starting the new "
-                        "instance now.\n",
-                        log_to_logfiles_only=True,
-                    )
+            if not self.is_slips_live_updating_event.is_set():
+                self.main.redis_man.stop_redis_server_after_analysis()
 
-                print(
-                    "[Process Manager] Slips shutdown gracefully\n",
-                    log_to_logfiles_only=True,
-                )
-            else:
-                print(
-                    f"[Process Manager] Slips didn't "
-                    f"shutdown gracefully - {reason}\n",
-                    log_to_logfiles_only=True,
-                )
+            self._print_shutdown_stats(
+                graceful_shutdown, analysis_time, reason, print
+            )
 
         except KeyboardInterrupt:
             return False

--- a/managers/process_manager.py
+++ b/managers/process_manager.py
@@ -1141,17 +1141,13 @@ class ProcessManager:
                 self.kill_all_children()
 
             if not self.is_slips_live_updating_event.is_set():
-                self.main.redis_man.decide_on_saving_the_redis_db()
+                self.main.redis_man.decide_on_saving_and_killing_the_redis_db()
 
                 if self.main.conf.export_labeled_flows():
                     format_ = self.main.conf.export_labeled_flows_to().lower()
                     self.main.db.export_labeled_flows(format_)
 
-                # if store_a_copy_of_zeek_files is set to yes in slips.yaml
-                # copy the whole zeek_files dir to the output dir
                 self.main.store_zeek_dir_copy()
-                # if delete_zeek_files is set to yes in slips.yaml,
-                # delete zeek_files/ dir
                 self.main.delete_zeek_files()
 
             analysis_time, end_date = self.get_analysis_time()

--- a/managers/process_manager.py
+++ b/managers/process_manager.py
@@ -1078,7 +1078,7 @@ class ProcessManager:
                 self.main.db.check_tw_to_close(close_all=True)
 
             graceful_shutdown = True
-            reason = ""
+            shutdown_reason = ""
             if self.main.mode == "daemonized":
                 self.kill_daemon_children()
                 profiles_len: int = self.main.db.get_profiles_len()
@@ -1102,7 +1102,7 @@ class ProcessManager:
                     if self.core_module_failure:
                         # dont wait for failed core modules to stop
                         self.kill_all_children()
-                        reason = "Core module failure."
+                        shutdown_reason = "Core module failure."
                         graceful_shutdown = False
                     else:
                         # Wait timeout_seconds for all the processes to finish
@@ -1122,27 +1122,27 @@ class ProcessManager:
                     # or slips was stuck looping for too long that the OS
                     # sent an automatic sigint to kill slips
                     # pass to kill the remaining modules
-                    reason = "User pressed ctr+c or Slips was killed by the OS"
+                    shutdown_reason = (
+                        "User pressed ctr+c or Slips was killed" " by the OS"
+                    )
                     graceful_shutdown = False
 
                 if time.time() - method_start_time >= timeout:
                     # getting here means we're killing them bc of the timeout
                     # not getting here means we're killing them bc of double
                     # ctr+c OR they terminated successfully
-                    reason = (
+                    shutdown_reason = (
                         f"Killing modules that took more than {timeout}"
                         f" mins to finish."
                     )
-                    print(reason)
+                    print(shutdown_reason)
                     graceful_shutdown = False
 
                 self.kill_all_children()
 
             if not self.is_slips_live_updating_event.is_set():
-                if self.main.args.save:
-                    self.main.save_the_db()
-                if self.main.redis_man.should_save_redis_db_after_analysis():
-                    self.main.redis_man.save_redis_db()
+                self.main.redis_man.decide_on_saving_the_redis_db()
+
                 if self.main.conf.export_labeled_flows():
                     format_ = self.main.conf.export_labeled_flows_to().lower()
                     self.main.db.export_labeled_flows(format_)
@@ -1165,7 +1165,7 @@ class ProcessManager:
                 self.main.redis_man.stop_redis_server_after_analysis()
 
             self._print_shutdown_stats(
-                graceful_shutdown, analysis_time, reason, print
+                graceful_shutdown, analysis_time, shutdown_reason, print
             )
 
         except KeyboardInterrupt:

--- a/managers/redis_manager.py
+++ b/managers/redis_manager.py
@@ -13,6 +13,9 @@ from slips_files.core.database.redis_db.database import RedisDB
 from slips_files.core.output import Output
 from slips_files.common.slips_utils import utils
 from slips_files.common.input_type import InputType
+from slips_files.common.output_paths import (
+    get_this_db_path_inside_output_dir,
+)
 from slips_files.core.database.database_manager import DBManager
 
 LOCALHOST = "127.0.0.1"
@@ -48,6 +51,70 @@ class RedisManager:
 
     def get_start_port(self):
         return self.start_port
+
+    def get_current_redis_port(self) -> int:
+        """
+        Return the Redis port used by the current Slips run.
+
+        Returns:
+            The configured Redis port, falling back to the default port.
+        """
+        return int(getattr(self.main, "redis_port", DEFAULT_REDIS_PORT))
+
+    def should_keep_redis_server_after_analysis(self) -> bool:
+        """
+        Decide whether the analysis Redis server should stay in memory.
+
+        Returns:
+            True when Redis must stay open for the web interface or because it
+            is the default cache port.
+        """
+        return (
+            self.main.args.webinterface
+            or self.get_current_redis_port() == DEFAULT_REDIS_PORT
+        )
+
+    def should_save_redis_db_after_analysis(self) -> bool:
+        """
+        Decide whether Slips should persist Redis after this analysis.
+
+        Returns:
+            True when Slips is not keeping Redis open for the web interface.
+        """
+        return not self.main.args.webinterface
+
+    def save_redis_db(self) -> bool:
+        """
+        Save Redis to the analysis output databases directory.
+
+        Returns:
+            True if Redis reported a successful save, False otherwise.
+        """
+        rdb_filepath = get_this_db_path_inside_output_dir(
+            self.main.args.output, "dump"
+        )
+        return bool(self.main.db.save(rdb_filepath))
+
+    def stop_redis_server_after_analysis(self) -> None:
+        """
+        Stop the analysis Redis server when it should not remain open.
+        """
+        if self.should_keep_redis_server_after_analysis():
+            return
+
+        redis_port = self.get_current_redis_port()
+        redis_pid = self.get_pid_of_redis_server(redis_port)
+        if not redis_pid:
+            self.remove_server_from_log(redis_port)
+            return
+
+        if self.kill_redis_server(redis_pid):
+            self.main.print(f"Killed Redis server on port {redis_port}.")
+            self.remove_server_from_log(redis_port)
+        else:
+            self.main.print(
+                f"Unable to kill Redis server on port {redis_port}."
+            )
 
     def log_redis_server_pid(self, redis_port: int, redis_pid: int):
         now = utils.get_human_readable_datetime()
@@ -96,7 +163,8 @@ class RedisManager:
 
         print(
             f"{self.main.args.db} loaded successfully.\n"
-            f"Run ./webinterface.sh and choose port {redis_port}"
+            f"Run ./slips.py -d {self.main.args.db} -w "
+            f"and choose port {redis_port}"
         )
 
     def load_db(self):
@@ -238,6 +306,21 @@ class RedisManager:
         Returns str(port) or false if there's no redis-server running on this
         port
         """
+        client = None
+        try:
+            client = redis.StrictRedis(
+                host=LOCALHOST,
+                port=port,
+                socket_connect_timeout=0.2,
+                socket_timeout=0.2,
+            )
+            return int(client.info(section="server")["process_id"])
+        except (redis.exceptions.RedisError, KeyError, TypeError, ValueError):
+            pass
+        finally:
+            if client:
+                client.connection_pool.disconnect()
+
         cmd = "ps aux | grep redis-server"
         process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         cmd_output, _ = process.communicate()

--- a/managers/redis_manager.py
+++ b/managers/redis_manager.py
@@ -81,7 +81,16 @@ class RedisManager:
         Returns:
             True when Slips is not keeping Redis open for the web interface.
         """
+        if self.main.args.save:
+            return True
+
         return not self.main.args.webinterface
+
+    def decide_on_saving_the_redis_db(self):
+        if self.main.redis_man.should_save_redis_db_after_analysis():
+            self.main.redis_man.save_redis_db()
+        else:
+            self.main.redis_man.print_reason_for_not_killing_redis()
 
     def save_redis_db(self) -> bool:
         """
@@ -94,6 +103,21 @@ class RedisManager:
             self.main.args.output, "dump"
         )
         return bool(self.main.db.save(rdb_filepath))
+
+    def print_reason_for_not_killing_redis(self):
+        reason = ""
+        if self.main.args.webinterface:
+            reason = "the web interface is running."
+        elif self.main.redis_port == 6379:
+            reason = (
+                "the default redis port should always stay up"
+                " for storing cached TI data."
+            )
+
+        print(
+            f"The redis server on port {self.main.redis_port} "
+            f"will not be killed. Reason: {reason}."
+        )
 
     def stop_redis_server_after_analysis(self) -> None:
         """

--- a/managers/redis_manager.py
+++ b/managers/redis_manager.py
@@ -93,16 +93,15 @@ class RedisManager:
             self.main.redis_man.print_reason_for_not_killing_redis()
 
     def save_redis_db(self) -> bool:
-        """
-        Save Redis to the analysis output databases directory.
-
-        Returns:
-            True if Redis reported a successful save, False otherwise.
-        """
         rdb_filepath = get_this_db_path_inside_output_dir(
             self.main.args.output, "dump"
         )
-        return bool(self.main.db.save(rdb_filepath))
+        saved = bool(self.main.db.save(rdb_filepath))
+        if saved:
+            self.main.print(f"Database saved to {rdb_filepath}")
+        else:
+            self.main.print("Faled to save the redis database.")
+        return saved
 
     def print_reason_for_not_killing_redis(self):
         reason = ""

--- a/managers/redis_manager.py
+++ b/managers/redis_manager.py
@@ -105,7 +105,9 @@ class RedisManager:
         )
         saved = bool(self.main.db.save(rdb_filepath))
         if saved:
-            self.main.print(f"The redis database is saved to {rdb_filepath}")
+            self.main.print(
+                f"The redis database is saved to " f"{rdb_filepath}.rdb"
+            )
         else:
             self.main.print("Failed to save the redis database.")
         return saved

--- a/managers/redis_manager.py
+++ b/managers/redis_manager.py
@@ -4,6 +4,7 @@ import contextlib
 import shutil
 import redis
 import os
+import psutil
 import socket
 import time
 import subprocess
@@ -677,7 +678,7 @@ class RedisManager:
             # server already killed!
             return False
 
-    def kill_redis_server(self, pid):
+    def kill_redis_server(self, pid: Union[int, str]) -> bool:
         """
         Kill the redis server on this pid
         """
@@ -688,24 +689,26 @@ class RedisManager:
             # the pid of it is 'not found'
             return False
 
-        # signal 0 is to check if the process is still running or not
-        # it returns 1 if the process used_redis_servers.txt exited
         try:
-            # check if the process is still running
-            while os.kill(pid, 0) != 1:
-                # sigterm is 9
-                os.kill(pid, 9)
-        except ProcessLookupError:
-            # ProcessLookupError: process already exited, sometimes this exception is raised
-            # but the process is still running, keep trying to kill it
+            process = psutil.Process(pid)
+            if process.status() == psutil.STATUS_ZOMBIE:
+                return True
+
+            process.kill()
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                if process.status() == psutil.STATUS_ZOMBIE:
+                    return True
+                time.sleep(0.1)
+            return False
+        except psutil.NoSuchProcess:
             return True
-        except PermissionError:
+        except psutil.AccessDenied:
             # PermissionError happens when the user tries to close redis-servers
             # opened by root while he's not root,
             # or when he tries to close redis-servers
             # opened without root while he's root
             return False
-        return True
 
     def remove_old_logline(self, redis_port):
         """

--- a/managers/redis_manager.py
+++ b/managers/redis_manager.py
@@ -41,6 +41,9 @@ class RedisManager:
         self.start_port = 32768
         self.end_port = 32850
         self.running_logfile = "running_slips_info.txt"
+        # slips sets this to true if it managed to save the redis dump.rdb
+        # to the output dir
+        self.saved_redis_dump = False
 
     def _clear_cached_redis_instance(self, port: int) -> None:
         """
@@ -52,7 +55,7 @@ class RedisManager:
     def get_start_port(self):
         return self.start_port
 
-    def get_current_redis_port(self) -> int:
+    def _get_current_redis_port(self) -> int:
         """
         Return the Redis port used by the current Slips run.
 
@@ -61,20 +64,18 @@ class RedisManager:
         """
         return int(getattr(self.main, "redis_port", DEFAULT_REDIS_PORT))
 
-    def should_keep_redis_server_after_analysis(self) -> bool:
+    def _should_keep_redis_server_after_analysis(self) -> bool:
         """
-        Decide whether the analysis Redis server should stay in memory.
+        Decide whether the started Redis server should stay in memory.
 
         Returns:
-            True when Redis must stay open for the web interface or because it
-            is the default cache port.
+            True when Redis must stay open, false otherwise.
         """
-        return (
-            self.main.args.webinterface
-            or self.get_current_redis_port() == DEFAULT_REDIS_PORT
-        )
+        # if slips failed to save the redis dump for any reason, keep the
+        # server up after the analysis to avoid losing the analysis
+        return not self.saved_redis_dump
 
-    def should_save_redis_db_after_analysis(self) -> bool:
+    def _should_save_redis_db_after_analysis(self) -> bool:
         """
         Decide whether Slips should persist Redis after this analysis.
 
@@ -86,24 +87,30 @@ class RedisManager:
 
         return not self.main.args.webinterface
 
-    def decide_on_saving_the_redis_db(self):
-        if self.main.redis_man.should_save_redis_db_after_analysis():
-            self.main.redis_man.save_redis_db()
+    def decide_on_saving_and_killing_the_redis_db(self) -> bool:
+        """
+        returns True if the redis dump was saved, and redis should be
+        safely killed. and False otherwise
+        """
+        if self._should_save_redis_db_after_analysis():
+            if self._save_redis_db():
+                self.saved_redis_dump = True
         else:
-            self.main.redis_man.print_reason_for_not_killing_redis()
+            self._print_reason_for_not_killing_redis()
+        return self.saved_redis_dump
 
-    def save_redis_db(self) -> bool:
+    def _save_redis_db(self) -> bool:
         rdb_filepath = get_this_db_path_inside_output_dir(
             self.main.args.output, "dump"
         )
         saved = bool(self.main.db.save(rdb_filepath))
         if saved:
-            self.main.print(f"Database saved to {rdb_filepath}")
+            self.main.print(f"The redis database is saved to {rdb_filepath}")
         else:
-            self.main.print("Faled to save the redis database.")
+            self.main.print("Failed to save the redis database.")
         return saved
 
-    def print_reason_for_not_killing_redis(self):
+    def _print_reason_for_not_killing_redis(self):
         reason = ""
         if self.main.args.webinterface:
             reason = "the web interface is running."
@@ -122,10 +129,10 @@ class RedisManager:
         """
         Stop the analysis Redis server when it should not remain open.
         """
-        if self.should_keep_redis_server_after_analysis():
+        if self._should_keep_redis_server_after_analysis():
             return
 
-        redis_port = self.get_current_redis_port()
+        redis_port = self._get_current_redis_port()
         redis_pid = self.get_pid_of_redis_server(redis_port)
         if not redis_pid:
             self.remove_server_from_log(redis_port)
@@ -136,7 +143,7 @@ class RedisManager:
             self.remove_server_from_log(redis_port)
         else:
             self.main.print(
-                f"Unable to kill Redis server on port {redis_port}."
+                f"Slips didn't kill the Redis server on port {redis_port}."
             )
 
     def log_redis_server_pid(self, redis_port: int, redis_pid: int):

--- a/managers/ui_manager.py
+++ b/managers/ui_manager.py
@@ -44,7 +44,7 @@ class UIManager:
 
     def start_webinterface(self):
         """
-        Starts the web interface shell script if -w is given
+        Starts the web interface if -w is given
         """
 
         def detach_child():
@@ -57,10 +57,6 @@ class UIManager:
             os.setpgrp()
 
         def run_webinterface():
-            # starting the wbeinterface using the shell script results
-            # in slips not being able to
-            # get the PID of the python proc started by the .sh script
-            # so we'll start it with python instead
             command = [sys.executable, "-m", "webinterface.app"]
 
             webinterface = subprocess.Popen(

--- a/slips/main.py
+++ b/slips/main.py
@@ -651,6 +651,7 @@ class Main:
                     # need this handler to be called only once when slips
                     # is shutting down
                     return
+
                 if not self.sigterm_received:
                     self.sigterm_received = True
                     self.print("SIGTERM received, shutting down slips.")
@@ -736,11 +737,6 @@ class Main:
             # comes here if zeek terminates while slips is still working
             pass
 
-        if self.sigterm_received:
-            with contextlib.suppress(Exception):
-                if self.redis_man.should_save_redis_db_after_analysis():
-                    self.redis_man.save_redis_db()
-                self.db.close_all_dbs()
-                self.redis_man.stop_redis_server_after_analysis()
-        else:
+        if not self.sigterm_received:
+            # to avoid calling this func twice when sigterm is received
             self.proc_man.shutdown_gracefully()

--- a/slips/main.py
+++ b/slips/main.py
@@ -765,6 +765,11 @@ class Main:
             # comes here if zeek terminates while slips is still working
             pass
 
-        if not self.sigterm_received:
-            # to avoid calling this func twice when sigterm is received
+        if self.sigterm_received:
+            with contextlib.suppress(Exception):
+                if self.redis_man.should_save_redis_db_after_analysis():
+                    self.redis_man.save_redis_db()
+                self.db.close_all_dbs()
+                self.redis_man.stop_redis_server_after_analysis()
+        else:
             self.proc_man.shutdown_gracefully()

--- a/slips/main.py
+++ b/slips/main.py
@@ -120,35 +120,6 @@ class Main:
         if not self.conf.get_cpu_profiler_enable():
             sys.exit(0)  # leaves any children started by slips as orphans
 
-    def save_the_db(self):
-        # save the db to the output dir of this analysis
-        # backups_dir = os.path.join(os.getcwd(), 'redis_backups/')
-        # try:
-        #     os.mkdir(backups_dir)
-        # except FileExistsError:
-        #     pass
-        backups_dir = self.args.output
-        # The name of the interface/pcap/nfdump/binetflow used is in self.input_information
-        # if the input is a zeek dir, remove the / at the end
-        if self.input_information.endswith("/"):
-            self.input_information = self.input_information[:-1]
-        # remove the path
-        self.input_information = os.path.basename(self.input_information)
-        # Remove the extension from the filename
-        with contextlib.suppress(ValueError):
-            self.input_information = self.input_information[
-                : self.input_information.index(".")
-            ]
-        # Give the exact path to save(), this is where our saved .rdb backup will be
-        rdb_filepath = os.path.join(backups_dir, self.input_information)
-        self.db.save(rdb_filepath)
-        # info will be lost only if you're out of space and redis
-        # can't write to dump.self.rdb, otherwise you're fine
-        print(
-            "[Main] [Warning] stop-writes-on-bgsave-error is set to no, "
-            "information may be lost in the redis backup file."
-        )
-
     def was_running_zeek(self) -> bool:
         """returns true if zeek was used in this run"""
         return (

--- a/slips_files/common/slips_utils.py
+++ b/slips_files/common/slips_utils.py
@@ -983,7 +983,7 @@ class Utils(object):
         :param return_type: can be seconds, minutes, hours or days
         """
         if start_time == float("-inf"):
-            # a lot of time passed since -inf
+            # a lot of time passed since -inf :D:D
             return 100000000000
 
         start_time = self.convert_to_datetime(start_time)

--- a/slips_files/core/database/redis_db/database.py
+++ b/slips_files/core/database/redis_db/database.py
@@ -1795,7 +1795,7 @@ class RedisDB(
         if os.path.exists(redis_db_path):
             shutil.copy2(redis_db_path, f"{safe_backup_file}.rdb")
             os.remove(redis_db_path)
-            self.print(f"Database saved to {safe_backup_file}.rdb")
+
             return True
 
         self.print(

--- a/slips_files/core/database/redis_db/database.py
+++ b/slips_files/core/database/redis_db/database.py
@@ -4,6 +4,7 @@ import shutil
 import socket
 
 from slips_files.common.output_paths import (
+    get_databases_dir_path_inside_output_dir,
     get_redis_logs_path_inside_output_dir,
 )
 from slips_files.common.printer import Printer
@@ -281,6 +282,15 @@ class RedisDB(
             cls.output_dir, f"redis-server-port-{cls.redis_port}.log"
         )
         cls._options.update({"logfile": logfile})
+        cls._options.update(
+            {
+                # manual SAVE writes the .rdb file to <output_dir>/databases
+                "dir": get_databases_dir_path_inside_output_dir(
+                    cls.output_dir
+                ),
+                "dbfilename": "dump.rdb",
+            }
+        )
 
         # -s for saving the db
         if cls.args.save:
@@ -291,9 +301,6 @@ class RedisDB(
                     # AOF is now enabled. Redis will write each operation to the
                     # AOF file.
                     "appendonly": "yes",
-                    # saves the .rdb file to <output_dir>
-                    "dir": cls.output_dir,
-                    "dbfilename": "dump.rdb",
                 }
             )
 
@@ -1774,27 +1781,75 @@ class RedisDB(
         # delete anything older than the most recent 20 servers
         self.r.ltrim(self.constants.DHCP_SERVERS, 0, max - 1)
 
-    def save(self, backup_file):
+    def _get_redis_dump_path_from_redis_config(self) -> str:
         """
-        Save the db to disk.
-        backup_file should be the path+name of the file you want to save the db in
+        Return the dump file path configured in the running Redis server.
+
+        Return:
+        Path Redis writes when SAVE is executed.
+        """
+        redis_dir = self.r.config_get("dir").get("dir", os.getcwd())
+        dbfilename = self.r.config_get("dbfilename").get(
+            "dbfilename", "dump.rdb"
+        )
+        return os.path.join(redis_dir, dbfilename)
+
+    def _save_rdb_with_redis_cli(self, backup_rdb: str) -> bool:
+        """
+        Save Redis to an RDB with redis-cli
+        Parameters:
+        backup_rdb: Path where redis-cli should write the RDB file.
+
+        Return:
+        True if redis-cli created the requested RDB file, False otherwise.
+        """
+        safe_port = utils.validate_port(self.redis_port)
+        result = subprocess.run(
+            [
+                "redis-cli",
+                "-h",
+                LOCALHOST,
+                "-p",
+                str(safe_port),
+                "--rdb",
+                backup_rdb,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        return result.returncode == 0 and os.path.exists(backup_rdb)
+
+    def save(self, backup_file: str) -> bool:
+        """
+        Saves the redis db to disk.
         If you -s the same file twice the old backup will be overwritten.
+
+        Parameters:
+        backup_file: Path without extension where the Redis dump should be saved.
+        it should be the path+name of the file you want to save the db in
+
+        Return:
+        True if the Redis dump was saved to the path, False otherwise.
         """
+        safe_backup_file = utils.validate_safe_path(backup_file)
+        safe_backup_rdb = f"{safe_backup_file}.rdb"
+        safe_backup_dir = os.path.dirname(safe_backup_rdb) or "."
+        os.makedirs(safe_backup_dir, exist_ok=True)
 
-        # use print statements in this function won't work because by the time this
-        # function is executed, the redis database would have already stopped
+        if self._save_rdb_with_redis_cli(safe_backup_rdb):
+            return True
 
-        # saves to /var/lib/redis/dump.rdb
-        # this path is only accessible by root
+        # Redis writes to the configured dir/dbfilename pair.
         self.r.save()
 
-        # gets the db saved to dump.rdb in the cwd
-        redis_db_path = os.path.join(os.getcwd(), "dump.rdb")
-        safe_backup_file = utils.validate_safe_path(backup_file)
+        redis_db_path = self._get_redis_dump_path_from_redis_config()
 
         if os.path.exists(redis_db_path):
-            shutil.copy2(redis_db_path, f"{safe_backup_file}.rdb")
-            os.remove(redis_db_path)
+            if os.path.abspath(redis_db_path) != os.path.abspath(
+                safe_backup_rdb
+            ):
+                shutil.copy2(redis_db_path, safe_backup_rdb)
+                os.remove(redis_db_path)
 
             return True
 

--- a/slips_files/core/database/redis_db/database.py
+++ b/slips_files/core/database/redis_db/database.py
@@ -224,6 +224,10 @@ class RedisDB(
             cls.output_dir, f"redis-server-port-{redis_port}.conf"
         )
 
+    @staticmethod
+    def _absolute_path(path: str) -> str:
+        return os.path.abspath(os.fspath(path))
+
     def _init_ttls(self):
         """sets the default and extended ttls for redis keys based on
         whether we're analysing files or interface"""
@@ -278,15 +282,17 @@ class RedisDB(
 
         # because slips may use different redis ports at the same time,
         # logs should be port specific
-        logfile = get_redis_logs_path_inside_output_dir(
-            cls.output_dir, f"redis-server-port-{cls.redis_port}.log"
+        logfile = cls._absolute_path(
+            get_redis_logs_path_inside_output_dir(
+                cls.output_dir, f"redis-server-port-{cls.redis_port}.log"
+            )
         )
         cls._options.update({"logfile": logfile})
         cls._options.update(
             {
                 # manual SAVE writes the .rdb file to <output_dir>/databases
-                "dir": get_databases_dir_path_inside_output_dir(
-                    cls.output_dir
+                "dir": cls._absolute_path(
+                    get_databases_dir_path_inside_output_dir(cls.output_dir)
                 ),
                 "dbfilename": "dump.rdb",
             }
@@ -446,6 +452,10 @@ class RedisDB(
         safe_conf_file = utils.validate_safe_path(
             cls._conf_file, must_exist=True
         )
+        logfile = cls._options.get("logfile")
+        if logfile:
+            os.makedirs(os.path.dirname(logfile), exist_ok=True)
+
         safe_port = utils.validate_port(cls.redis_port)
         cmd = [
             "redis-server",
@@ -474,9 +484,11 @@ class RedisDB(
         if process.returncode != 0:
             if utils.is_port_in_use(cls.redis_port):
                 return True
+            str_cmd = " ".join(cmd)
             raise RuntimeError(
                 f"database._start_redis_server: "
-                f"Redis did not start properly.\n{stderr}\n{stdout}"
+                f"Redis did not start properly using: "
+                f"{str_cmd}.\n{stderr}\n{stdout}"
             )
 
         return True

--- a/slips_files/core/database/redis_db/database.py
+++ b/slips_files/core/database/redis_db/database.py
@@ -1795,11 +1795,11 @@ class RedisDB(
         if os.path.exists(redis_db_path):
             shutil.copy2(redis_db_path, f"{safe_backup_file}.rdb")
             os.remove(redis_db_path)
-            print(f"[Main] Database saved to {safe_backup_file}.rdb")
+            self.print(f"Database saved to {safe_backup_file}.rdb")
             return True
 
-        print(
-            f"[DB] Error Saving: Cannot find the redis "
+        self.print(
+            f"Error Saving: Cannot find the redis "
             f"database directory {redis_db_path}"
         )
         return False

--- a/slips_files/core/input/zeek/utils/zeek_file_remover.py
+++ b/slips_files/core/input/zeek/utils/zeek_file_remover.py
@@ -20,7 +20,7 @@ class ZeekFileRemover:
         self.thread = threading.Thread(
             target=self.remove_old_zeek_files,
             daemon=True,
-            name="input_remover_thread",
+            name="rotated_zeek_logs_remover_thread",
         )
         self._started = False
 

--- a/tests/common_test_utils.py
+++ b/tests/common_test_utils.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2021 Sebastian Garcia <sebastian.garcia@agents.fel.cvut.cz>
 # SPDX-License-Identifier: GPL-2.0-only
 import sqlite3
+import re
 from contextlib import contextmanager
 from importlib.util import find_spec
 from pathlib import Path
@@ -11,7 +12,6 @@ import binascii
 import subprocess
 import base64
 import sys
-import time
 import socket
 import threading
 from typing import (
@@ -21,7 +21,6 @@ from typing import (
 from pathlib import PosixPath
 from unittest.mock import Mock
 import yaml
-import redis
 
 IS_IN_A_DOCKER_CONTAINER = os.environ.get("IS_IN_A_DOCKER_CONTAINER", False)
 
@@ -230,73 +229,6 @@ def allocate_integration_test_port(test_name: str, port_label: str) -> int:
     return port
 
 
-def start_test_redis_server(redis_port: int) -> None:
-    """
-    Ensure a Redis server is running for an integration test.
-
-    :param redis_port: Redis port required by the integration test
-    :return: None
-    """
-    client = redis.StrictRedis(host="localhost", port=redis_port, db=0)
-    try:
-        client.ping()
-        return
-    except redis.exceptions.ConnectionError:
-        pass
-    finally:
-        client.connection_pool.disconnect()
-
-    if shutil.which("redis-server") is None:
-        import pytest
-
-        pytest.skip("Missing integration runtime dependencies: redis-server")
-
-    subprocess.check_call(
-        ["redis-server", "--port", str(redis_port), "--daemonize", "yes"]
-    )
-
-    deadline = time.time() + 5
-    while time.time() < deadline:
-        client = redis.StrictRedis(host="localhost", port=redis_port, db=0)
-        try:
-            client.ping()
-            return
-        except redis.exceptions.ConnectionError:
-            time.sleep(0.1)
-        finally:
-            client.connection_pool.disconnect()
-
-    raise RuntimeError(
-        f"Redis server did not become ready on integration test port {redis_port}."
-    )
-
-
-def close_test_redis_server(redis_port: int) -> bool:
-    """
-    Flush and stop the Redis server used by an integration test.
-
-    :param redis_port: Redis port used by the test
-    :return: True when a Redis server was reached and shutdown was attempted
-    """
-    client = redis.StrictRedis(host="localhost", port=redis_port, db=0)
-    try:
-        client.ping()
-    except redis.exceptions.ConnectionError:
-        return False
-
-    try:
-        client.flushall()
-        client.flushdb()
-        client.script_flush()
-        client.shutdown(save=False)
-    except redis.exceptions.ConnectionError:
-        return True
-    finally:
-        client.connection_pool.disconnect()
-
-    return True
-
-
 def get_slips_test_command(arguments):
     """
     Build a Slips CLI command that uses the current Python interpreter.
@@ -401,6 +333,26 @@ def check_for_text(txt, output_dir):
             if txt in line:
                 return True
     return False
+
+
+def get_total_analyzed_ips_from_output(output_dir) -> int:
+    """
+    Return the highest total analyzed IP count printed by Slips.
+
+    Parameters:
+        output_dir: Integration test output directory.
+
+    Return value:
+        Highest total analyzed IP count found in slips_output.txt.
+    """
+    slips_output = os.path.join(output_dir, "slips_output.txt")
+    total_ips = 0
+    pattern = re.compile(r"Total analyzed IPs:\s*(\d+)")
+    with open(slips_output, "r") as f:
+        for line in f:
+            if match := pattern.search(line):
+                total_ips = max(total_ips, int(match.group(1)))
+    return total_ips
 
 
 def get_label_count_from_output_db(output_dir, label):

--- a/tests/common_test_utils.py
+++ b/tests/common_test_utils.py
@@ -248,7 +248,8 @@ def get_total_profiles(db):
 
 
 def is_evidence_present(log_file, expected_evidence):
-    """Function to read the log file line by line and returns when it finds the expected evidence"""
+    """Function to read the log file line by line and returns when it finds
+    the expected evidence"""
     with open(log_file, "r") as f:
         while line := f.readline():
             if expected_evidence in line:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,7 +4,6 @@ import importlib.util
 import pytest
 from tests.common_test_utils import (
     allocate_integration_test_port,
-    start_test_redis_server,
 )
 
 
@@ -31,9 +30,6 @@ def integration_port_factory(request):
         :param port_label: Label describing the allocated port
         :return: Allocated TCP port
         """
-        port = allocate_integration_test_port(request.node.nodeid, port_label)
-        if "redis" in port_label.lower():
-            start_test_redis_server(port)
-        return port
+        return allocate_integration_test_port(request.node.nodeid, port_label)
 
     return allocate

--- a/tests/integration/test_config_files/test_config_files.py
+++ b/tests/integration/test_config_files/test_config_files.py
@@ -15,14 +15,13 @@ from tests.common_test_utils import (
     create_output_dir,
     assert_no_errors,
     check_for_text,
-    close_test_redis_server,
+    get_total_analyzed_ips_from_output,
     get_label_count_from_output_db,
     run_slips,
     get_slips_test_command,
     modify_yaml_config,
     skip_if_missing_runtime_dependencies,
 )
-from tests.module_factory import ModuleFactory
 
 alerts_file = "alerts.log"
 CONFIG_FILES_DIR = Path("output/integration/config_files")
@@ -95,10 +94,7 @@ def test_conf_file(
         print("Slip is done, checking for errors in the output dir.")
         assert_no_errors(output_dir)
         print("Comparing profiles with expected profiles")
-        database = ModuleFactory().create_db_manager_obj(
-            redis_port, output_dir=output_dir, start_redis_server=False
-        )
-        profiles = database.get_profiles_len()
+        profiles = get_total_analyzed_ips_from_output(output_dir)
         # expected_profiles is more than 50 because we're using direction = all
         assert profiles > expected_profiles
         print("Checking for a random evidence")
@@ -137,7 +133,6 @@ def test_conf_file(
         success = True
     finally:
         if success:
-            close_test_redis_server(redis_port)
             config_file.unlink(missing_ok=True)
             shutil.rmtree(output_dir)
 
@@ -204,6 +199,5 @@ def test_conf_file2(
         success = True
     finally:
         if success:
-            close_test_redis_server(redis_port)
             config_file.unlink(missing_ok=True)
             shutil.rmtree(output_dir)

--- a/tests/integration/test_dataset/test_dataset.py
+++ b/tests/integration/test_dataset/test_dataset.py
@@ -10,11 +10,10 @@ from tests.common_test_utils import (
     is_evidence_present,
     create_output_dir,
     assert_no_errors,
-    close_test_redis_server,
+    get_total_analyzed_ips_from_output,
     get_slips_test_command,
     skip_if_missing_runtime_dependencies,
 )
-from tests.module_factory import ModuleFactory
 import pytest
 import shutil
 import os
@@ -82,10 +81,7 @@ def test_binetflow(
 
         assert_no_errors(output_dir)
 
-        database = ModuleFactory().create_db_manager_obj(
-            redis_port, output_dir=output_dir, start_redis_server=False
-        )
-        profiles = database.get_profiles_len()
+        profiles = get_total_analyzed_ips_from_output(output_dir)
         assert profiles > expected_profiles
 
         log_file = output_dir / "alerts" / alerts_file
@@ -93,7 +89,6 @@ def test_binetflow(
         success = True
     finally:
         if success:
-            close_test_redis_server(redis_port)
             shutil.rmtree(output_dir)
 
 
@@ -134,10 +129,7 @@ def test_suricata(
 
         assert_no_errors(output_dir)
 
-        database = ModuleFactory().create_db_manager_obj(
-            redis_port, output_dir=output_dir, start_redis_server=False
-        )
-        profiles = database.get_profiles_len()
+        profiles = get_total_analyzed_ips_from_output(output_dir)
         # todo the profiles should be way more than 10, maybe 76, but it varies
         #  each run, we need to sy why
         assert profiles > 10
@@ -149,7 +141,6 @@ def test_suricata(
         success = True
     finally:
         if success:
-            close_test_redis_server(redis_port)
             shutil.rmtree(output_dir)
 
 
@@ -182,14 +173,10 @@ def test_nfdump(nfdump_path, output_dir, integration_port_factory):
         # this function returns when slips is done
         run_slips(command)
 
-        database = ModuleFactory().create_db_manager_obj(
-            redis_port, output_dir=output_dir, start_redis_server=False
-        )
-        profiles = database.get_profiles_len()
+        profiles = get_total_analyzed_ips_from_output(output_dir)
         assert_no_errors(output_dir)
         assert profiles > 0
         success = True
     finally:
         if success:
-            close_test_redis_server(redis_port)
             shutil.rmtree(output_dir)

--- a/tests/integration/test_fides/test_fides.py
+++ b/tests/integration/test_fides/test_fides.py
@@ -16,7 +16,6 @@ from modules.fides.persistence.fides_sqlite_db import FidesSQLiteDB
 from tests.common_test_utils import (
     create_output_dir,
     assert_no_errors,
-    close_test_redis_server,
     modify_yaml_config,
 )
 from tests.module_factory import ModuleFactory
@@ -359,7 +358,6 @@ def test_conf_file2(path, output_dir, integration_port_factory):
     finally:
         if process is not None and process.poll() is None:
             stop_process_group(process, "fides slips")
-        close_test_redis_server(redis_port)
         if test_db.exists():
             test_db.unlink()
         shutil.rmtree(
@@ -435,6 +433,7 @@ def test_trust_recommendation_response(
     ]
     # success = False
     process = None
+    cached_network_opinion = None
 
     print(f"command: {' '.join(command)}")
 
@@ -489,17 +488,19 @@ def test_trust_recommendation_response(
 
         # these 30s are the time we give slips to process the msg
         countdown(30, "sigterm")
+        db = ModuleFactory().create_db_manager_obj(
+            redis_port, output_dir=output_dir, start_redis_server=False
+        )
+        cached_network_opinion = db.get_cached_network_opinion(
+            "stratosphere.org", 200000000000, 200000000000
+        )
+        db.close_all_dbs()
         stop_process_group(process, "fides slips")
 
     print(f"Slips with PID {process.pid} was killed.")
 
     print("Slips is done, checking for errors in the output dir.")
     assert_no_errors(output_dir)
-
-    print("Checking database")
-    db = ModuleFactory().create_db_manager_obj(
-        redis_port, output_dir=output_dir, start_redis_server=False
-    )
 
     # assert db.get_msgs_received_at_runtime("fides")["fides2network"] == "1"
     print("Checking Fides' data outlets")
@@ -508,9 +509,7 @@ def test_trust_recommendation_response(
     assert fdb.get_peer_trust_data("peer2").service_history != []
     assert fdb.get_peer_trust_data("peer1").service_history_size == 1
     assert fdb.get_peer_trust_data("peer2").service_history_size == 1
-    assert db.get_cached_network_opinion(
-        "stratosphere.org", 200000000000, 200000000000
-    ) == {
+    assert cached_network_opinion == {
         "target": "stratosphere.org",
         "score": "0.0",
         "confidence": "0.0",
@@ -522,7 +521,6 @@ def test_trust_recommendation_response(
     # finally:
     #     if process is not None and process.poll() is None:
     #         stop_process_group(process, "fides slips")
-    #     close_test_redis_server(redis_port)
     #     if permanent_db.exists():
     #         permanent_db.unlink()
     #     shutil.rmtree(

--- a/tests/integration/test_iris/test_iris.py
+++ b/tests/integration/test_iris/test_iris.py
@@ -13,7 +13,6 @@ import redis
 from tests.common_test_utils import (
     create_output_dir,
     assert_no_errors,
-    close_test_redis_server,
     modify_yaml_config,
 )
 import pytest
@@ -626,8 +625,6 @@ def test_messaging(
         assert_peer2_results(output_dir_peer, log_file_second_iris)
         success = True
     finally:
-        close_test_redis_server(redis_port)
-        close_test_redis_server(peer_redis_port)
         if peer2_key_path is not None and peer2_key_path.exists():
             peer2_key_path.unlink()
         shutil.rmtree(

--- a/tests/integration/test_pcap_dataset/test_pcap_dataset.py
+++ b/tests/integration/test_pcap_dataset/test_pcap_dataset.py
@@ -5,11 +5,10 @@ from tests.common_test_utils import (
     is_evidence_present,
     create_output_dir,
     assert_no_errors,
-    close_test_redis_server,
+    get_total_analyzed_ips_from_output,
     get_slips_test_command,
     skip_if_missing_runtime_dependencies,
 )
-from tests.module_factory import ModuleFactory
 import pytest
 import shutil
 import os
@@ -51,10 +50,7 @@ def test_pcap(
         run_slips(command)
         assert_no_errors(output_dir)
 
-        db = ModuleFactory().create_db_manager_obj(
-            redis_port, output_dir=output_dir, start_redis_server=False
-        )
-        profiles = db.get_profiles_len()
+        profiles = get_total_analyzed_ips_from_output(output_dir)
         assert profiles > expected_profiles
 
         log_file = output_dir / "alerts" / alerts_file
@@ -62,5 +58,4 @@ def test_pcap(
         success = True
     finally:
         if success:
-            close_test_redis_server(redis_port)
             shutil.rmtree(output_dir)

--- a/tests/integration/test_portscans/test_portscans.py
+++ b/tests/integration/test_portscans/test_portscans.py
@@ -10,10 +10,9 @@ from tests.common_test_utils import (
     create_output_dir,
     assert_no_errors,
     get_slips_test_command,
-    close_test_redis_server,
+    get_total_analyzed_ips_from_output,
     skip_if_missing_runtime_dependencies,
 )
-from tests.module_factory import ModuleFactory
 
 alerts_file = "alerts.log"
 
@@ -51,10 +50,7 @@ def test_horizontal(path, output_dir, integration_port_factory):
         run_slips(command)
 
         assert_no_errors(output_dir)
-        database = ModuleFactory().create_db_manager_obj(
-            redis_port, output_dir=output_dir, start_redis_server=False
-        )
-        profiles = database.get_profiles_len()
+        profiles = get_total_analyzed_ips_from_output(output_dir)
         assert profiles > 0
 
         log_file = output_dir / "alerts" / alerts_file
@@ -62,7 +58,6 @@ def test_horizontal(path, output_dir, integration_port_factory):
         success = True
     finally:
         if success:
-            close_test_redis_server(redis_port)
             shutil.rmtree(output_dir)
 
 
@@ -95,10 +90,7 @@ def test_vertical(path, output_dir, integration_port_factory):
 
         assert_no_errors(output_dir)
 
-        database = ModuleFactory().create_db_manager_obj(
-            redis_port, output_dir=output_dir, start_redis_server=False
-        )
-        profiles = database.get_profiles_len()
+        profiles = get_total_analyzed_ips_from_output(output_dir)
         assert profiles > 0
 
         log_file = output_dir / "alerts" / alerts_file
@@ -106,5 +98,4 @@ def test_vertical(path, output_dir, integration_port_factory):
         success = True
     finally:
         if success:
-            close_test_redis_server(redis_port)
             shutil.rmtree(output_dir)

--- a/tests/integration/test_slips_params.py
+++ b/tests/integration/test_slips_params.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Garcia <sebastian.garcia@agents.fel.cvut.cz>
+# SPDX-License-Identifier: GPL-2.0-only
+"""
+Integration tests for Slips command-line parameters.
+"""
+
+import subprocess
+import sys
+
+from tests.common_test_utils import skip_if_missing_runtime_dependencies
+
+
+def run_slips_param(param: str) -> subprocess.CompletedProcess[str]:
+    """
+    Run slips.py with a single command-line parameter.
+
+    :param param: Slips command-line parameter to pass
+    :return: Completed Slips subprocess
+    """
+    return subprocess.run(
+        [sys.executable, "./slips.py", param],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_multiinstance_requires_input_source() -> None:
+    """
+    Check that -m exits cleanly with the expected missing-input message.
+
+    :return: None
+    """
+    skip_if_missing_runtime_dependencies(python_modules=("termcolor",))
+
+    result = run_slips_param("-m")
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 255
+    assert "[Main] You need to define an input source." in output
+
+
+def test_clearcache_deletes_cache_database() -> None:
+    """
+    Check that -cc clears the Redis cache database successfully.
+
+    :return: None
+    """
+    skip_if_missing_runtime_dependencies(
+        python_modules=("termcolor",), binaries=("redis-server",)
+    )
+
+    result = run_slips_param("-cc")
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 0
+    assert "Deleting the cache database in the Redis server" in output
+    assert "Done deleting the cache database." in output

--- a/tests/integration/test_zeek_dataset/test_zeek_dataset.py
+++ b/tests/integration/test_zeek_dataset/test_zeek_dataset.py
@@ -5,11 +5,10 @@ from tests.common_test_utils import (
     is_evidence_present,
     create_output_dir,
     assert_no_errors,
-    close_test_redis_server,
+    get_total_analyzed_ips_from_output,
     get_slips_test_command,
     skip_if_missing_runtime_dependencies,
 )
-from tests.module_factory import ModuleFactory
 import pytest
 import shutil
 import os
@@ -162,10 +161,7 @@ def test_zeek_conn_log(
         run_slips(command)
         assert_no_errors(output_dir)
 
-        database = ModuleFactory().create_db_manager_obj(
-            redis_port, output_dir=output_dir, start_redis_server=False
-        )
-        profiles = database.get_profiles_len()
+        profiles = get_total_analyzed_ips_from_output(output_dir)
         assert profiles > expected_profiles
 
         log_file = output_dir / "alerts" / alerts_file
@@ -173,5 +169,4 @@ def test_zeek_conn_log(
         success = True
     finally:
         if success:
-            close_test_redis_server(redis_port)
             shutil.rmtree(output_dir)

--- a/tests/unit/managers/test_redis_manager.py
+++ b/tests/unit/managers/test_redis_manager.py
@@ -109,21 +109,15 @@ def test_load_redis_db(redis_port, redis_pid, db_path, mock_db):
 
 
 @pytest.mark.parametrize(
-    "redis_port, webinterface, expected",
-    [
-        (DEFAULT_REDIS_PORT, False, True),
-        (32768, True, True),
-        (32768, False, False),
-    ],
+    "saved_redis_dump, expected", [(False, True), (True, False)]
 )
 def test_should_keep_redis_server_after_analysis(
-    redis_port, webinterface, expected, mock_db
+    saved_redis_dump, expected, mock_db
 ):
     redis_manager = ModuleFactory().create_redis_manager_obj()
-    redis_manager.main.redis_port = redis_port
-    redis_manager.main.args.webinterface = webinterface
+    redis_manager.saved_redis_dump = saved_redis_dump
 
-    result = redis_manager.should_keep_redis_server_after_analysis()
+    result = redis_manager._should_keep_redis_server_after_analysis()
 
     assert result is expected
 
@@ -143,7 +137,7 @@ def test_should_save_redis_db_after_analysis(
     redis_manager.main.args.save = save
     redis_manager.main.args.webinterface = webinterface
 
-    result = redis_manager.should_save_redis_db_after_analysis()
+    result = redis_manager._should_save_redis_db_after_analysis()
 
     assert result is expected
 
@@ -158,7 +152,7 @@ def test_save_redis_db_after_analysis(mock_db):
         "managers.redis_manager.get_this_db_path_inside_output_dir",
         return_value="output_dir/databases/dump",
     ) as mock_get_path:
-        result = redis_manager.save_redis_db()
+        result = redis_manager._save_redis_db()
 
     assert result is True
     mock_get_path.assert_called_once_with("output_dir", "dump")
@@ -166,7 +160,7 @@ def test_save_redis_db_after_analysis(mock_db):
         "output_dir/databases/dump"
     )
     redis_manager.main.print.assert_called_once_with(
-        "Database saved to output_dir/databases/dump"
+        "The redis database is saved to output_dir/databases/dump.rdb"
     )
 
 
@@ -175,6 +169,7 @@ def test_stop_redis_server_after_analysis_kills_non_default_port(mock_db):
     redis_manager.main.redis_port = 32768
     redis_manager.main.args.webinterface = False
     redis_manager.main.print = Mock()
+    redis_manager.saved_redis_dump = True
 
     with (
         patch.object(

--- a/tests/unit/managers/test_redis_manager.py
+++ b/tests/unit/managers/test_redis_manager.py
@@ -129,14 +129,18 @@ def test_should_keep_redis_server_after_analysis(
 
 
 @pytest.mark.parametrize(
-    "webinterface, expected",
+    "save, webinterface, expected",
     [
-        (False, True),
-        (True, False),
+        (False, False, True),
+        (False, True, False),
+        (True, True, True),
     ],
 )
-def test_should_save_redis_db_after_analysis(webinterface, expected, mock_db):
+def test_should_save_redis_db_after_analysis(
+    save, webinterface, expected, mock_db
+):
     redis_manager = ModuleFactory().create_redis_manager_obj()
+    redis_manager.main.args.save = save
     redis_manager.main.args.webinterface = webinterface
 
     result = redis_manager.should_save_redis_db_after_analysis()
@@ -148,6 +152,7 @@ def test_save_redis_db_after_analysis(mock_db):
     redis_manager = ModuleFactory().create_redis_manager_obj()
     redis_manager.main.args.output = "output_dir"
     redis_manager.main.db.save = Mock(return_value=True)
+    redis_manager.main.print = Mock()
 
     with patch(
         "managers.redis_manager.get_this_db_path_inside_output_dir",
@@ -159,6 +164,9 @@ def test_save_redis_db_after_analysis(mock_db):
     mock_get_path.assert_called_once_with("output_dir", "dump")
     redis_manager.main.db.save.assert_called_once_with(
         "output_dir/databases/dump"
+    )
+    redis_manager.main.print.assert_called_once_with(
+        "Database saved to output_dir/databases/dump"
     )
 
 

--- a/tests/unit/managers/test_redis_manager.py
+++ b/tests/unit/managers/test_redis_manager.py
@@ -104,8 +104,113 @@ def test_load_redis_db(redis_port, redis_pid, db_path, mock_db):
         mock_remove.assert_called_once_with(redis_port)
         mock_print.assert_called_once_with(
             f"{db_path} loaded successfully.\n"
-            f"Run ./webinterface.sh and choose port {redis_port}"
+            f"Run ./slips.py -d {db_path} -w and choose port {redis_port}"
         )
+
+
+@pytest.mark.parametrize(
+    "redis_port, webinterface, expected",
+    [
+        (DEFAULT_REDIS_PORT, False, True),
+        (32768, True, True),
+        (32768, False, False),
+    ],
+)
+def test_should_keep_redis_server_after_analysis(
+    redis_port, webinterface, expected, mock_db
+):
+    redis_manager = ModuleFactory().create_redis_manager_obj()
+    redis_manager.main.redis_port = redis_port
+    redis_manager.main.args.webinterface = webinterface
+
+    result = redis_manager.should_keep_redis_server_after_analysis()
+
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "webinterface, expected",
+    [
+        (False, True),
+        (True, False),
+    ],
+)
+def test_should_save_redis_db_after_analysis(webinterface, expected, mock_db):
+    redis_manager = ModuleFactory().create_redis_manager_obj()
+    redis_manager.main.args.webinterface = webinterface
+
+    result = redis_manager.should_save_redis_db_after_analysis()
+
+    assert result is expected
+
+
+def test_save_redis_db_after_analysis(mock_db):
+    redis_manager = ModuleFactory().create_redis_manager_obj()
+    redis_manager.main.args.output = "output_dir"
+    redis_manager.main.db.save = Mock(return_value=True)
+
+    with patch(
+        "managers.redis_manager.get_this_db_path_inside_output_dir",
+        return_value="output_dir/databases/dump",
+    ) as mock_get_path:
+        result = redis_manager.save_redis_db()
+
+    assert result is True
+    mock_get_path.assert_called_once_with("output_dir", "dump")
+    redis_manager.main.db.save.assert_called_once_with(
+        "output_dir/databases/dump"
+    )
+
+
+def test_stop_redis_server_after_analysis_kills_non_default_port(mock_db):
+    redis_manager = ModuleFactory().create_redis_manager_obj()
+    redis_manager.main.redis_port = 32768
+    redis_manager.main.args.webinterface = False
+    redis_manager.main.print = Mock()
+
+    with (
+        patch.object(
+            redis_manager, "get_pid_of_redis_server", return_value=1234
+        ) as mock_get_pid,
+        patch.object(
+            redis_manager, "kill_redis_server", return_value=True
+        ) as mock_kill,
+        patch.object(redis_manager, "remove_server_from_log") as mock_remove,
+    ):
+        redis_manager.stop_redis_server_after_analysis()
+
+    mock_get_pid.assert_called_once_with(32768)
+    mock_kill.assert_called_once_with(1234)
+    mock_remove.assert_called_once_with(32768)
+    redis_manager.main.print.assert_called_once_with(
+        "Killed Redis server on port 32768."
+    )
+
+
+@pytest.mark.parametrize(
+    "redis_port, webinterface",
+    [
+        (DEFAULT_REDIS_PORT, False),
+        (32768, True),
+    ],
+)
+def test_stop_redis_server_after_analysis_keeps_required_ports(
+    redis_port, webinterface, mock_db
+):
+    redis_manager = ModuleFactory().create_redis_manager_obj()
+    redis_manager.main.redis_port = redis_port
+    redis_manager.main.args.webinterface = webinterface
+
+    with (
+        patch.object(redis_manager, "get_pid_of_redis_server") as mock_get_pid,
+        patch.object(redis_manager, "kill_redis_server") as mock_kill,
+        patch.object(redis_manager, "remove_server_from_log") as mock_remove,
+    ):
+        redis_manager.stop_redis_server_after_analysis()
+
+    mock_get_pid.assert_not_called()
+    mock_kill.assert_not_called()
+    mock_remove.assert_not_called()
 
 
 def test_load_db_success(mock_db):
@@ -336,10 +441,42 @@ def test_print_port_in_use(port, mock_db):
 def test_get_pid_of_redis_server(port, cmd_output, expected_pid, mock_db):
     redis_manager = ModuleFactory().create_redis_manager_obj()
 
-    with patch("subprocess.Popen") as mock_popen:
+    with (
+        patch(
+            "managers.redis_manager.redis.StrictRedis",
+            side_effect=redis.exceptions.ConnectionError,
+        ),
+        patch("subprocess.Popen") as mock_popen,
+    ):
         mock_popen.return_value.communicate.return_value = (cmd_output, None)
         result = redis_manager.get_pid_of_redis_server(port)
         assert result == expected_pid
+
+
+def test_get_pid_of_redis_server_uses_redis_process_id(mock_db):
+    redis_manager = ModuleFactory().create_redis_manager_obj()
+    mock_client = Mock()
+    mock_client.info.return_value = {"process_id": "1234"}
+
+    with (
+        patch(
+            "managers.redis_manager.redis.StrictRedis",
+            return_value=mock_client,
+        ) as mock_redis,
+        patch("subprocess.Popen") as mock_popen,
+    ):
+        result = redis_manager.get_pid_of_redis_server(32768)
+
+    assert result == 1234
+    mock_redis.assert_called_once_with(
+        host="127.0.0.1",
+        port=32768,
+        socket_connect_timeout=0.2,
+        socket_timeout=0.2,
+    )
+    mock_client.info.assert_called_once_with(section="server")
+    mock_client.connection_pool.disconnect.assert_called_once()
+    mock_popen.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/managers/test_redis_manager.py
+++ b/tests/unit/managers/test_redis_manager.py
@@ -3,6 +3,7 @@
 import shutil
 from unittest.mock import patch, mock_open, Mock, call
 import os
+import psutil
 import redis
 import pytest
 
@@ -649,31 +650,62 @@ def test_get_port_of_redis_server(cmd_output, pid, expected_port, mock_db):
 
 
 @pytest.mark.parametrize(
-    "pid, os_kill_side_effect, " "expected_result, expected_calls",
+    "pid, statuses, expected_result",
     [
-        # Testcase 1: Process killed successfully after one try
-        (
-            1234,
-            [None, ProcessLookupError],
-            True,
-            [call(1234, 0), call(1234, 9)],
-        ),
-        # Testcase 2: Process already killed
-        (5678, [ProcessLookupError], True, [call(5678, 0)]),
-        # Testcase 3: Permission error while killing
-        (9101, [PermissionError], False, [call(9101, 0)]),
+        (1234, ["running", "zombie"], True),
+        (5678, ["zombie"], True),
+        (9101, ["running", "running"], False),
     ],
 )
-def test_kill_redis_server(
-    pid, os_kill_side_effect, expected_result, expected_calls, mock_db
-):
+def test_kill_redis_server(pid, statuses, expected_result, mock_db):
+    """
+    Test Redis process killing for running, zombie, and timed-out processes.
+    """
     redis_manager = ModuleFactory().create_redis_manager_obj()
+    mock_process = Mock()
+    mock_process.status.side_effect = statuses
 
-    with patch("os.kill", side_effect=os_kill_side_effect) as mock_kill:
+    with (
+        patch(
+            "managers.redis_manager.psutil.Process",
+            return_value=mock_process,
+        ),
+        patch("managers.redis_manager.time.time", side_effect=[0, 1, 6]),
+        patch("managers.redis_manager.time.sleep"),
+    ):
         result = redis_manager.kill_redis_server(pid)
 
-        assert result == expected_result
-        mock_kill.assert_has_calls(expected_calls)
+    assert result == expected_result
+    if statuses[0] == "zombie":
+        mock_process.kill.assert_not_called()
+    else:
+        mock_process.kill.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "exception, expected_result",
+    [
+        ("no_such_process", True),
+        ("access_denied", False),
+    ],
+)
+def test_kill_redis_server_handles_psutil_exceptions(
+    exception, expected_result, mock_db
+):
+    """
+    Test Redis process killing handles missing and inaccessible processes.
+    """
+    redis_manager = ModuleFactory().create_redis_manager_obj()
+
+    with patch("managers.redis_manager.psutil.Process") as mock_process:
+        if exception == "no_such_process":
+            mock_process.side_effect = psutil.NoSuchProcess(pid=1234)
+        else:
+            mock_process.side_effect = psutil.AccessDenied(pid=1234)
+
+        result = redis_manager.kill_redis_server(1234)
+
+    assert result == expected_result
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/slips/test_main.py
+++ b/tests/unit/slips/test_main.py
@@ -262,27 +262,6 @@ def test_get_input_file_type(given_path, cmd_result, expected_input_type):
 
 
 @pytest.mark.parametrize(
-    "input_information, expected_filepath",
-    [
-        # Test Case 1: Simple filename
-        ("input.pcap", "output/input"),
-        # Test Case 2: Filename with trailing slash
-        ("input.pcap/", "output/input"),
-        # Test Case 3: Filename with path
-        ("path/to/input.pcap", "output/input"),
-    ],
-)
-def test_save_the_db(input_information, expected_filepath):
-    main = ModuleFactory().create_main_obj()
-    main.input_information = input_information
-    main.args = MagicMock()
-    main.args.output = "output"
-    main.db = MagicMock()
-    main.save_the_db()
-    main.db.save.assert_called_once_with(expected_filepath)
-
-
-@pytest.mark.parametrize(
     "input_type, is_running_non_stop, expected_result",
     [
         # Test Case 1: PCAP input, not a growing Zeek directory

--- a/tests/unit/slips_files/core/database/test_database.py
+++ b/tests/unit/slips_files/core/database/test_database.py
@@ -11,11 +11,26 @@ from typing import Any
 import redis
 import json
 import os
+import pytest
 
 from slips_files.core.flows.zeek import Conn
 from slips_files.core.database.database_manager import DBManager
 from slips_files.core.database.redis_db.database import RedisDB
 from tests.module_factory import ModuleFactory
+
+
+@pytest.fixture(autouse=True)
+def ensure_redis_options(monkeypatch: Any) -> None:
+    """
+    Ensure Redis options exist when ModuleFactory skips config generation.
+
+    Parameters:
+        monkeypatch: Pytest fixture used to patch RedisDB class state.
+
+    Return value:
+        None.
+    """
+    monkeypatch.setattr(RedisDB, "_options", {}, raising=False)
 
 
 # random values for testing

--- a/tests/unit/slips_files/core/database/test_database.py
+++ b/tests/unit/slips_files/core/database/test_database.py
@@ -3,7 +3,10 @@
 from unittest.mock import (
     Mock,
     call,
+    patch,
 )
+from pathlib import Path
+from typing import Any
 
 import redis
 import json
@@ -204,10 +207,169 @@ def test_setup_config_file_uses_isolated_path_and_preserves_save(
 
     conf_contents = expected_conf.read_text(encoding="utf-8").splitlines()
     assert 'save ""' in conf_contents
+    assert f"dir {tmp_path / 'databases'}" in conf_contents
+    assert "dbfilename dump.rdb" in conf_contents
     assert (
         f"logfile {tmp_path / 'redis' / f'redis-server-port-{RedisDB.redis_port}.log'}"
         in conf_contents
     )
+
+
+def test_setup_config_file_enables_autosave_when_save_enabled(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """Test Redis autosave options are set when save is enabled."""
+    template = tmp_path / "redis.conf.template"
+    template.write_text(
+        'daemonize yes\nsave ""\nappendonly no\n', encoding="utf-8"
+    )
+
+    monkeypatch.setattr(RedisDB, "_conf_file_template", str(template))
+    monkeypatch.setattr(RedisDB, "output_dir", tmp_path, raising=False)
+    monkeypatch.setattr(RedisDB, "redis_port", 6379, raising=False)
+    monkeypatch.setattr(RedisDB, "args", Mock(save=True), raising=False)
+
+    RedisDB._setup_config_file()
+
+    expected_conf = (
+        tmp_path / "redis" / f"redis-server-port-{RedisDB.redis_port}.conf"
+    )
+    conf_contents = expected_conf.read_text(encoding="utf-8").splitlines()
+
+    assert "save 30 500" in conf_contents
+    assert "appendonly yes" in conf_contents
+    assert f"dir {tmp_path / 'databases'}" in conf_contents
+    assert "dbfilename dump.rdb" in conf_contents
+
+
+def test_setup_config_file_uses_absolute_redis_paths(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """Test generated Redis configs use absolute paths for dir and logfile."""
+    template = tmp_path / "redis.conf.template"
+    template.write_text(
+        'daemonize yes\nsave ""\nappendonly no\n', encoding="utf-8"
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(RedisDB, "_conf_file_template", str(template))
+    monkeypatch.setattr(
+        RedisDB, "output_dir", "relative-output", raising=False
+    )
+    monkeypatch.setattr(RedisDB, "redis_port", 6379, raising=False)
+    monkeypatch.setattr(RedisDB, "args", Mock(save=False), raising=False)
+
+    RedisDB._setup_config_file()
+
+    expected_logfile = (
+        tmp_path / "relative-output" / "redis" / "redis-server-port-6379.log"
+    )
+    expected_dir = tmp_path / "relative-output" / "databases"
+    conf_contents = (
+        Path(RedisDB._conf_file).read_text(encoding="utf-8").splitlines()
+    )
+
+    assert f"logfile {expected_logfile}" in conf_contents
+    assert f"dir {expected_dir}" in conf_contents
+    assert expected_logfile.parent.exists()
+
+
+def test_save_points_redis_at_backup_path(tmp_path: Path) -> None:
+    """Test save writes the Redis RDB to the backup path."""
+    db = object.__new__(RedisDB)
+    backup_file = tmp_path / "databases" / "dump"
+    redis_dump = backup_file.parent / "dump.rdb"
+    backup_file.parent.mkdir()
+    redis_dump.write_text("redis dump", encoding="utf-8")
+    db.r = Mock()
+    db.r.config_get.side_effect = [
+        {"dir": str(backup_file.parent)},
+        {"dbfilename": "dump.rdb"},
+    ]
+    db._save_rdb_with_redis_cli = Mock(return_value=True)
+    db.print = Mock()
+
+    assert db.save(str(backup_file)) is True
+
+    db._save_rdb_with_redis_cli.assert_called_once_with(
+        str(backup_file.parent / "dump.rdb")
+    )
+    db.r.save.assert_not_called()
+    assert redis_dump.read_text(encoding="utf-8") == "redis dump"
+    db.print.assert_not_called()
+
+
+def test_save_copies_dump_from_configured_redis_dir(tmp_path: Path) -> None:
+    """Test save copies the RDB if Redis reports a different dump path."""
+    db = object.__new__(RedisDB)
+    redis_dir = tmp_path / "redis-data"
+    redis_dir.mkdir()
+    redis_dump = redis_dir / "custom.rdb"
+    redis_dump.write_text("redis dump", encoding="utf-8")
+    backup_file = tmp_path / "databases" / "dump"
+    backup_file.parent.mkdir()
+    db.r = Mock()
+    db.r.config_get.side_effect = [
+        {"dir": str(redis_dir)},
+        {"dbfilename": "custom.rdb"},
+    ]
+    db._save_rdb_with_redis_cli = Mock(return_value=False)
+    db.print = Mock()
+
+    assert db.save(str(backup_file)) is True
+
+    db._save_rdb_with_redis_cli.assert_called_once_with(
+        str(backup_file.parent / "dump.rdb")
+    )
+    db.r.save.assert_called_once()
+    assert (backup_file.parent / "dump.rdb").read_text(
+        encoding="utf-8"
+    ) == "redis dump"
+    assert not redis_dump.exists()
+    db.print.assert_not_called()
+
+
+def test_save_keeps_dump_when_redis_already_saved_to_backup_path(
+    tmp_path: Path,
+) -> None:
+    """Test save does not delete the target RDB when Redis writes there."""
+    db = object.__new__(RedisDB)
+    backup_file = tmp_path / "databases" / "dump"
+    backup_file.parent.mkdir()
+    redis_dump = backup_file.parent / "dump.rdb"
+    redis_dump.write_text("redis dump", encoding="utf-8")
+    db.r = Mock()
+    db.r.config_get.side_effect = [
+        {"dir": str(backup_file.parent)},
+        {"dbfilename": "dump.rdb"},
+    ]
+    db._save_rdb_with_redis_cli = Mock(return_value=False)
+    db.print = Mock()
+
+    assert db.save(str(backup_file)) is True
+
+    db._save_rdb_with_redis_cli.assert_called_once_with(
+        str(backup_file.parent / "dump.rdb")
+    )
+    db.r.save.assert_called_once()
+    assert redis_dump.read_text(encoding="utf-8") == "redis dump"
+    db.print.assert_not_called()
+
+
+def test_save_rdb_with_redis_cli_writes_requested_file(tmp_path: Path) -> None:
+    """Test redis-cli RDB export reports success when the file is created."""
+    db = object.__new__(RedisDB)
+    db.redis_port = 6379
+    backup_rdb = tmp_path / "dump.rdb"
+
+    def create_rdb_file(*args: Any, **kwargs: Any) -> Mock:
+        backup_rdb.write_text("redis dump", encoding="utf-8")
+        return Mock(returncode=0)
+
+    with patch("subprocess.run", side_effect=create_rdb_file) as mock_run:
+        assert db._save_rdb_with_redis_cli(str(backup_rdb)) is True
+
+    mock_run.assert_called_once()
 
 
 def test_init_p2p_trust_db_uses_permanent_dir(tmp_path, monkeypatch):

--- a/webinterface.sh
+++ b/webinterface.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-
-if [ -x ".venv/bin/python3" ]; then
-    .venv/bin/python3 -m webinterface.app
-else
-    python3 -m webinterface.app
-fi

--- a/webinterface/app.py
+++ b/webinterface/app.py
@@ -1,21 +1,40 @@
 # SPDX-FileCopyrightText: 2021 Sebastian Garcia <sebastian.garcia@agents.fel.cvut.cz>
 # SPDX-License-Identifier: GPL-2.0-only
 import secrets
+from pathlib import Path
+from typing import Set, Tuple
 
 from flask import Flask, abort, jsonify, render_template, request
+from werkzeug.datastructures import FileStorage
+from werkzeug.exceptions import RequestEntityTooLarge
+from werkzeug.utils import secure_filename
 
 from slips_files.common.parsers.config_parser import ConfigParser
-from .database.database import db
+from .database.database import db, db_obj
 from .database.signals import message_sent
 from .analysis.analysis import analysis
 from .general.general import general
 from .documentation.documentation import documentation
-from .utils import get_open_redis_ports_in_order
+from .utils import (
+    get_open_redis_ports_in_order,
+    has_rdb_extension,
+    is_redis_rdb_file,
+)
+
+MAX_RDB_UPLOAD_SIZE = 512 * 1024 * 1024
+RDB_UPLOAD_DIR = "webinterface/uploaded_rdb"
 
 
-def create_app():
+def create_app() -> Flask:
+    """
+    Create and configure the Flask web interface.
+
+    Return:
+    Configured Flask app.
+    """
     app = Flask(__name__)
     app.config["JSON_SORT_KEYS"] = False  # disable sorting of timewindows
+    app.config["MAX_CONTENT_LENGTH"] = MAX_RDB_UPLOAD_SIZE
     return app
 
 
@@ -23,14 +42,14 @@ app = create_app()
 CSRF_TOKEN = secrets.token_hex(32)
 
 
-def get_csrf_token():
+def get_csrf_token() -> str:
     """
     Return the in-memory CSRF token for the DB switch action.
     """
     return CSRF_TOKEN
 
 
-def get_available_redis_ports():
+def get_available_redis_ports() -> Set[int]:
     """
     Return the list of available Redis ports exposed by Slips.
     """
@@ -41,8 +60,69 @@ def get_available_redis_ports():
     }
 
 
+def has_valid_csrf_token() -> bool:
+    """
+    Check the CSRF token from a state-changing request.
+
+    Return:
+    True when the request includes the expected CSRF token.
+    """
+    csrf_token = request.headers.get("X-CSRF-Token")
+    return csrf_token == CSRF_TOKEN
+
+
+def redis_warning_response(
+    warning: str, status_code: int
+) -> Tuple[object, int]:
+    """
+    Build a JSON warning response for Redis upload failures.
+
+    Parameters:
+    warning: User-facing warning to render in the web interface.
+    status_code: HTTP status code for the response.
+
+    Return:
+    Flask JSON response and status code.
+    """
+    return jsonify({"ok": False, "warning": warning}), status_code
+
+
+def save_uploaded_rdb(uploaded_file: FileStorage) -> str:
+    """
+    Save an uploaded Redis RDB file under a generated relative path.
+
+    Parameters:
+    uploaded_file: Flask file upload object.
+
+    Return:
+    Relative path where the upload was saved.
+    """
+    Path(RDB_UPLOAD_DIR).mkdir(parents=True, exist_ok=True)
+    filename = f"{secrets.token_hex(16)}.rdb"
+    upload_path = Path(RDB_UPLOAD_DIR) / filename
+    uploaded_file.stream.seek(0)
+    uploaded_file.save(upload_path)
+    return upload_path.as_posix()
+
+
+def remove_uploaded_rdb(rdb_path: str) -> None:
+    """
+    Remove a saved uploaded RDB file.
+
+    Parameters:
+    rdb_path: Relative path returned by save_uploaded_rdb.
+
+    Return:
+    None.
+    """
+    try:
+        Path(rdb_path).unlink()
+    except FileNotFoundError:
+        return
+
+
 @app.route("/redis")
-def read_redis_port():
+def read_redis_port() -> dict:
     """
     is called when changing the db from the button at the top right
     prints the available redis dbs and ports for the user to choose ffrom
@@ -51,34 +131,88 @@ def read_redis_port():
     return {"data": res}
 
 
+@app.errorhandler(RequestEntityTooLarge)
+def handle_upload_too_large(
+    error: RequestEntityTooLarge,
+) -> Tuple[object, int]:
+    """
+    Return a JSON warning when a Redis database upload is too large.
+
+    Parameters:
+    error: Flask exception for oversized requests.
+
+    Return:
+    Flask JSON response and HTTP 413 status code.
+    """
+    return redis_warning_response(
+        "The uploaded Redis database is too large.", 413
+    )
+
+
+@app.route("/redis/upload", methods=["POST"])
+def upload_redis_database() -> Tuple[object, int]:
+    """
+    Verify, load, and switch to an uploaded Redis RDB database.
+
+    Return:
+    Flask JSON response with the selected Redis port or a warning.
+    """
+    if not has_valid_csrf_token():
+        abort(403)
+
+    uploaded_file = request.files.get("redis_db")
+    if uploaded_file is None:
+        return redis_warning_response("Choose a Redis RDB file first.", 400)
+
+    filename = secure_filename(uploaded_file.filename or "")
+    if not filename:
+        return redis_warning_response("Choose a Redis RDB file first.", 400)
+
+    if not has_rdb_extension(filename):
+        return redis_warning_response("Only .rdb files are accepted.", 400)
+
+    if not is_redis_rdb_file(uploaded_file.stream):
+        return redis_warning_response(
+            "The uploaded file is not a valid Redis RDB file.", 400
+        )
+
+    rdb_path = save_uploaded_rdb(uploaded_file)
+    loaded, warning, redis_port = db_obj.load_uploaded_rdb(rdb_path, filename)
+    remove_uploaded_rdb(rdb_path)
+    if not loaded:
+        return redis_warning_response(warning, 422)
+
+    return jsonify({"ok": True, "redis_port": redis_port}), 200
+
+
 @app.route("/")
-def index():
+def index() -> str:
     return render_template(
         "app.html", title="Slips", csrf_token=get_csrf_token()
     )
 
 
 @app.route("/db/<int:new_port>", methods=["POST"])
-def get_post_javascript_data(new_port):
+def get_post_javascript_data(new_port: int) -> object:
     """
     is called when the user chooses another db to connect to from the
     button at the top right (from /redis)
     should send a msg to update_db() in database.py
     """
-    csrf_token = request.headers.get("X-CSRF-Token")
-    if csrf_token != CSRF_TOKEN:
+    if not has_valid_csrf_token():
         abort(403)
 
     if new_port not in get_available_redis_ports():
         abort(404)
 
-    if not message_sent.send(new_port):
+    responses = message_sent.send(new_port)
+    if not responses or not all(response for _, response in responses):
         abort(503)
     return jsonify({"ok": True, "redis_port": new_port})
 
 
 @app.route("/info")
-def set_pcap_info():
+def set_pcap_info() -> dict:
     """
     Set information about the pcap.
     """

--- a/webinterface/database/database.py
+++ b/webinterface/database/database.py
@@ -1,19 +1,34 @@
 # SPDX-FileCopyrightText: 2021 Sebastian Garcia <sebastian.garcia@agents.fel.cvut.cz>
 # SPDX-License-Identifier: GPL-2.0-only
 from typing import (
+    Any,
     Dict,
     Optional,
+    Tuple,
 )
 import os
+from pathlib import Path
+import secrets
+import subprocess
+import time
+
+import redis
 
 from slips_files.common.parsers.config_parser import ConfigParser
 from slips_files.core.database.database_manager import DBManager
 from slips_files.core.output import Output
+from slips_files.core.database.redis_db.database import RedisDB
 from .signals import message_sent
 from webinterface.utils import (
     get_open_redis_ports_in_order,
     get_open_redis_servers,
+    is_port_open,
 )
+
+LOCALHOST = "127.0.0.1"
+IMPORTED_REDIS_OUTPUT_DIR = "webinterface/imported_redis"
+IMPORTED_REDIS_START_PORT = 32851
+IMPORTED_REDIS_END_PORT = 32950
 
 
 class Database(object):
@@ -24,16 +39,29 @@ class Database(object):
     def __init__(self):
         # connect to the db manager
         self.db: DBManager = self.get_db_manager_obj()
+        self.imported_redis_ports: set[int] = set()
 
-    def set_db(self, port):
-        """changes the redis db we're connected to"""
-        new_db = self.get_db_manager_obj(port)
+    def set_db(self, port: int, output_dir: Optional[str] = None) -> bool:
+        """
+        Change the Redis database used by the web interface.
+
+        Parameters:
+        port: Redis port to connect to.
+        output_dir: Optional output directory for Redis instances that are not
+            listed in running_slips_info.txt.
+
+        Return:
+        True when the database connection was switched successfully.
+        """
+        new_db = self.get_db_manager_obj(port, output_dir=output_dir)
         if new_db is None:
             return False
         self.db = new_db
         return True
 
-    def get_db_manager_obj(self, port: int = False) -> Optional[DBManager]:
+    def get_db_manager_obj(
+        self, port: Optional[int] = None, output_dir: Optional[str] = None
+    ) -> Optional[DBManager]:
         """
         Connects to redis db through the DBManager
         connects to the latest opened redis server if no port is given
@@ -46,8 +74,10 @@ class Database(object):
             ]
             port = last_opened_port
 
-        dbs: Dict[int, dict] = get_open_redis_servers()
-        output_dir = dbs[str(port)]["output_dir"]
+        if output_dir is None:
+            dbs: Dict[int, dict] = get_open_redis_servers()
+            output_dir = dbs[str(port)]["output_dir"]
+
         logger = Output(
             stdout=os.path.join(output_dir, "slips.log"),
             stderr=os.path.join(output_dir, "errors.log"),
@@ -69,13 +99,245 @@ class Database(object):
         except RuntimeError:
             return
 
+    def load_uploaded_rdb(
+        self, rdb_path: str, display_name: str
+    ) -> Tuple[bool, str, Optional[int]]:
+        """
+        Start Redis with an uploaded RDB file and switch the web interface.
+
+        Parameters:
+        rdb_path: Relative path to the uploaded RDB file.
+        display_name: Sanitized filename to show in Redis metadata.
+
+        Return:
+        Tuple of success flag, warning message, and Redis port when available.
+        """
+        port = self._get_available_import_port()
+        if port is None:
+            return False, "No local Redis port is available.", None
+
+        output_dir = self._create_import_output_dir()
+        started, warning = self._start_redis_from_rdb(
+            rdb_path, output_dir, port
+        )
+        if not started:
+            self._shutdown_redis(port)
+            self._clear_cached_redis_instance(port)
+            return False, warning, None
+
+        if not self.set_db(port, output_dir=output_dir):
+            self._shutdown_redis(port)
+            self._clear_cached_redis_instance(port)
+            return (
+                False,
+                "Slips could not use the uploaded Redis database.",
+                None,
+            )
+
+        previous_imported_ports = set(self.imported_redis_ports)
+        self.imported_redis_ports = {port}
+        self._stop_imported_redis_servers(previous_imported_ports)
+        self._set_imported_db_name(display_name)
+        return True, "", port
+
+    def _get_available_import_port(self) -> Optional[int]:
+        """
+        Find an unused localhost port for a web-uploaded Redis database.
+
+        Return:
+        An available TCP port, or None if none in the reserved range is free.
+        """
+        for port in range(
+            IMPORTED_REDIS_START_PORT, IMPORTED_REDIS_END_PORT + 1
+        ):
+            if not is_port_open(port):
+                return port
+        return None
+
+    def _create_import_output_dir(self) -> str:
+        """
+        Create an output directory for a web-uploaded Redis database.
+
+        Return:
+        Relative output directory path.
+        """
+        token = secrets.token_hex(16)
+        output_dir = os.path.join(IMPORTED_REDIS_OUTPUT_DIR, token)
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        return output_dir
+
+    def _start_redis_from_rdb(
+        self, rdb_path: str, output_dir: str, port: int
+    ) -> Tuple[bool, str]:
+        """
+        Start a local Redis server backed by an uploaded RDB file.
+
+        Parameters:
+        rdb_path: Relative path to the uploaded RDB file.
+        output_dir: Relative directory for Redis logs.
+        port: Local TCP port to bind Redis to.
+
+        Return:
+        Tuple of success flag and warning message.
+        """
+        rdb = Path(rdb_path)
+        cmd = [
+            "redis-server",
+            "config/redis.conf.template",
+            "--port",
+            str(port),
+            "--bind",
+            LOCALHOST,
+            "--daemonize",
+            "yes",
+            "--dir",
+            os.fspath(rdb.parent),
+            "--dbfilename",
+            rdb.name,
+        ]
+        process = subprocess.run(
+            cmd,
+            cwd=os.getcwd(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            text=True,
+        )
+        if process.returncode != 0:
+            return (
+                False,
+                "Redis could not start with the uploaded database.",
+            )
+
+        if not self._wait_for_redis(port):
+            return (
+                False,
+                "Redis rejected or could not load the uploaded database.",
+            )
+
+        return True, ""
+
+    def _wait_for_redis(self, port: int, timeout: float = 5.0) -> bool:
+        """
+        Wait until Redis accepts commands on a local port.
+
+        Parameters:
+        port: Redis port to poll.
+        timeout: Maximum number of seconds to wait.
+
+        Return:
+        True when Redis responds to PING before the timeout.
+        """
+        client = redis.StrictRedis(
+            host=LOCALHOST,
+            port=port,
+            db=0,
+            socket_connect_timeout=0.2,
+            socket_timeout=0.2,
+        )
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                return bool(client.ping())
+            except redis.exceptions.RedisError:
+                time.sleep(0.2)
+        return False
+
+    def _set_imported_db_name(self, display_name: str) -> None:
+        """
+        Store a display name for the uploaded Redis database when supported.
+
+        Parameters:
+        display_name: Sanitized filename to show in the web interface.
+
+        Return:
+        None.
+        """
+        try:
+            self.db.set_input_metadata({"name": display_name})
+        except (AttributeError, redis.exceptions.RedisError, TypeError):
+            return
+
+    def _stop_imported_redis_servers(self, ports: set[int]) -> None:
+        """
+        Stop old Redis servers created from previous web uploads.
+
+        Parameters:
+        ports: Imported Redis ports to stop.
+
+        Return:
+        None.
+        """
+        for port in ports:
+            self._shutdown_redis(port)
+            self._clear_cached_redis_instance(port)
+
+    def _shutdown_redis(self, port: int) -> None:
+        """
+        Shut down a Redis server without saving data.
+
+        Parameters:
+        port: Redis port to stop.
+
+        Return:
+        None.
+        """
+        try:
+            client = redis.StrictRedis(host=LOCALHOST, port=port, db=0)
+            client.shutdown(save=False)
+        except redis.exceptions.RedisError:
+            return
+
+    def _clear_cached_redis_instance(self, port: int) -> None:
+        """
+        Remove a RedisDB singleton cached for a local port.
+
+        Parameters:
+        port: Redis port whose cached instance should be removed.
+
+        Return:
+        None.
+        """
+        if port in RedisDB.instances:
+            del RedisDB.instances[port]
+
+
+class DatabaseProxy:
+    """
+    Delegates database calls to the currently selected DBManager instance.
+    """
+
+    def __init__(self, database: Database) -> None:
+        """
+        Store the mutable database holder.
+
+        Parameters:
+        database: Database holder that owns the current DBManager.
+
+        Return:
+        None.
+        """
+        self.database = database
+
+    def __getattr__(self, name: str) -> Any:
+        """
+        Delegate unknown attributes to the active DBManager.
+
+        Parameters:
+        name: Attribute name requested by callers.
+
+        Return:
+        Attribute from the active DBManager.
+        """
+        return getattr(self.database.db, name)
+
 
 db_obj = Database()
-db: DBManager = db_obj.db
+db: DatabaseProxy = DatabaseProxy(db_obj)
 
 
 @message_sent.connect
-def update_db(port):
+def update_db(port: int) -> bool:
     """is called when the user changes the used redis server from the web
     interface"""
     return db_obj.set_db(port)

--- a/webinterface/static/app.css
+++ b/webinterface/static/app.css
@@ -8,14 +8,21 @@
     font-size: 21px;
 }
 
-#slips_custom_navbar li a {
+#slips_custom_navbar li a,
+#slips_custom_navbar li button {
     display: inline-block;
     width: 100%;
     padding: 10px;
     text-decoration: none;
     color: grey;
+    background: transparent;
+    border: 0;
 }
 
 #slips_custom_navbar .nav-link.active {
     color: #0d6efd !important;
+}
+
+#redis_upload_warning {
+    margin: 10px 0 0 0;
 }

--- a/webinterface/static/app.js
+++ b/webinterface/static/app.js
@@ -53,6 +53,60 @@ async function switchRedisDb(port) {
     return response.json();
 }
 
+function setRedisUploadWarning(message) {
+    /*
+        Render Redis upload warnings without inserting HTML.
+    */
+    const warningElement = document.getElementById("redis_upload_warning");
+    warningElement.textContent = message;
+    warningElement.classList.remove("d-none");
+}
+
+function clearRedisUploadWarning() {
+    /*
+        Hide the Redis upload warning.
+    */
+    const warningElement = document.getElementById("redis_upload_warning");
+    warningElement.textContent = "";
+    warningElement.classList.add("d-none");
+}
+
+function setBrowseRedisButtonLoading(isLoading) {
+    /*
+        Toggle the Browse Redis database button loading state.
+    */
+    const browseRedisButton = document.getElementById("browse_redis_button");
+    const icon = document.createElement("i");
+    icon.className = isLoading ? "fa fa-spinner fa-spin" : "fa fa-folder-open";
+    const label = isLoading ? " Loading Redis database" : " Browse redis database";
+    browseRedisButton.disabled = isLoading;
+    browseRedisButton.replaceChildren(icon, document.createTextNode(label));
+}
+
+async function uploadRedisRdb(file) {
+    /*
+        Upload a Redis RDB file and switch the active web interface DB.
+    */
+    const formData = new FormData();
+    formData.append("redis_db", file);
+
+    const response = await fetch("/redis/upload", {
+        method: "POST",
+        headers: {
+            "X-CSRF-Token": csrfToken
+        },
+        credentials: "same-origin",
+        body: formData
+    });
+    const data = await response.json();
+
+    if (!response.ok || !data.ok) {
+        throw new Error(data.warning || "Failed to use uploaded Redis database.");
+    }
+
+    return data;
+}
+
 function initializeWidgetsAndListeners() {
     const redisModalElement = document.getElementById("modal_choose_redis");
     const redisModal = new bootstrap.Modal(redisModalElement, {
@@ -81,6 +135,37 @@ function initializeWidgetsAndListeners() {
     $('#changedb_button').click(function (event) {
         event.preventDefault();
         redisModal.show();
+    })
+
+    $('#browse_redis_button').click(function () {
+        clearRedisUploadWarning();
+        document.getElementById("redis_rdb_file").click();
+    })
+
+    $('#redis_rdb_file').change(async function () {
+        const file = this.files[0];
+        if (!file) {
+            return;
+        }
+
+        if (!file.name.toLowerCase().endsWith(".rdb")) {
+            setRedisUploadWarning("Only .rdb files are accepted.");
+            this.value = "";
+            return;
+        }
+
+        try {
+            setBrowseRedisButtonLoading(true);
+            clearRedisUploadWarning();
+            await uploadRedisRdb(file);
+            window.location.reload();
+        } catch (error) {
+            console.error(error);
+            setRedisUploadWarning(error.message);
+        } finally {
+            setBrowseRedisButtonLoading(false);
+            this.value = "";
+        }
     })
 
     redisModalElement.addEventListener('show.bs.modal', function () {

--- a/webinterface/templates/app.html
+++ b/webinterface/templates/app.html
@@ -81,11 +81,19 @@
         </a>
       </li>
       <li class="nav-item">
+        <button type="button" id="browse_redis_button" class="nav-link btn-primary">
+          <i class="fa fa-folder-open" aria-hidden="true"></i>
+          Browse redis database
+        </button>
+        <input type="file" id="redis_rdb_file" accept=".rdb" hidden>
+      </li>
+      <li class="nav-item">
         <a type="button" id="reload_button" class="nav-link btn-primary">
           <i class="fa fa-refresh" aria-hidden="true"></i>
         </a>
       </li>
     </ul>
+    <div id="redis_upload_warning" class="alert alert-warning d-none" role="alert"></div>
 
 
 

--- a/webinterface/utils.py
+++ b/webinterface/utils.py
@@ -3,9 +3,13 @@
 import os
 import socket
 from typing import (
+    BinaryIO,
     Dict,
     List,
 )
+
+RDB_HEADER_SIZE = 9
+RDB_MAGIC = b"REDIS"
 
 
 def is_port_open(port: int) -> bool:
@@ -15,6 +19,43 @@ def is_port_open(port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(0.2)
         return sock.connect_ex(("127.0.0.1", port)) == 0
+
+
+def has_rdb_extension(filename: str) -> bool:
+    """
+    Check whether a filename uses the Redis RDB extension.
+
+    Parameters:
+    filename: Uploaded filename to inspect.
+
+    Return:
+    True when the filename ends with .rdb.
+    """
+    return os.path.splitext(filename)[1].lower() == ".rdb"
+
+
+def is_redis_rdb_file(file_obj: BinaryIO) -> bool:
+    """
+    Verify a file-like object has a Redis RDB header.
+
+    Parameters:
+    file_obj: Binary stream positioned anywhere in the uploaded file.
+
+    Return:
+    True when the stream starts with a Redis RDB magic header and version.
+    """
+    position = file_obj.tell()
+    try:
+        file_obj.seek(0)
+        header = file_obj.read(RDB_HEADER_SIZE)
+    finally:
+        file_obj.seek(position)
+
+    return (
+        len(header) == RDB_HEADER_SIZE
+        and header.startswith(RDB_MAGIC)
+        and header[len(RDB_MAGIC) :].isdigit()
+    )
 
 
 def get_open_redis_ports_in_order() -> List[Dict[str, str]]:


### PR DESCRIPTION
closes #1831
- if the used redis server is using port 6379 we dont kill it when slips is done with the analysis to avoid losing the cache db.
- if -w was used we dont kill the server
- dropped support for the webinterface.sh