### PR TITLE
Sebas add dns for ipv6

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -140,7 +140,8 @@ and high if the destination ip is the one outside of local network.
 
 Slips ignores evidence of this type when the destination IP is a private IP outside of local network and is
 communicating on port 53/UDP. Slips marks that destination address as the DNS server when 5 flows are seen using port
-53/udp while having DNS answers. this is likely a DNS misconfiguration hence a FP.
+53/udp while having DNS answers. The same heuristic applies to private IPv4 and IPv6 DNS servers. this is likely a
+DNS misconfiguration hence a FP.
 
 
 ### Weird HTTP methods

--- a/docs/features.md
+++ b/docs/features.md
@@ -143,6 +143,10 @@ communicating on port 53/UDP. Slips marks that destination address as the DNS se
 53/udp while having DNS answers. The same heuristic applies to private IPv4 and IPv6 DNS servers. this is likely a
 DNS misconfiguration hence a FP.
 
+Slips also ignores this evidence when the checked IP is one of the DNS resolver addresses configured on the host and
+the matching DNS server port is 53. This applies to both IPv4 and IPv6 resolver addresses and covers requests sent to
+the resolver and replies coming back from it.
+
 
 ### Weird HTTP methods
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -117,6 +117,11 @@ Slips detects when a private IP is connected to another private IP with threat l
 But it skips this alert when it's a DNS or a DHCP connection on port
 53, 67 or 68 UDP to the gateway IP.
 
+Slips also skips this alert for DNS traffic on port 53 and for DHCPv6 traffic
+on ports 546 and 547. When Slips sees a private DNS flow in the analyzed
+traffic, it records that destination address as a DNS server and prints it to
+the display and to slips.log.
+
 
 ### Connection to private IPs outside the current local network
 
@@ -139,13 +144,19 @@ and high if the destination ip is the one outside of local network.
 
 
 Slips ignores evidence of this type when the destination IP is a private IP outside of local network and is
-communicating on port 53/UDP. Slips marks that destination address as the DNS server when 5 flows are seen using port
-53/udp while having DNS answers. The same heuristic applies to private IPv4 and IPv6 DNS servers. this is likely a
-DNS misconfiguration hence a FP.
+communicating on port 53/UDP. Slips marks that destination address as the DNS server as soon as it sees a private
+DNS flow in `dns.log` and prints `Detected DNS server by traffic heuristic: <ip>` to the display and `slips.log`.
+The same heuristic applies to private IPv4 and IPv6 DNS servers. this is likely a DNS misconfiguration hence a FP.
 
-Slips also ignores this evidence when the checked IP is one of the DNS resolver addresses configured on the host and
-the matching DNS server port is 53. This applies to both IPv4 and IPv6 resolver addresses and covers requests sent to
-the resolver and replies coming back from it.
+Slips also ignores this evidence when the checked IP is one of the DNS
+servers detected from the analyzed DNS traffic and the matching DNS server
+port is 53. This applies to both IPv4 and IPv6 resolver addresses and
+covers requests sent to the resolver and replies coming back from it.
+
+For `CONNECTION_TO_PRIVATE_IP`, Slips suppresses DHCPv6 traffic on ports 546
+and 547. This avoids false positives when the same local network device
+provides both DNS and DHCPv6 services but answers with a different IPv6
+address, such as a link-local address.
 
 
 ### Weird HTTP methods

--- a/docs/flow_alerts.md
+++ b/docs/flow_alerts.md
@@ -384,6 +384,10 @@ communicating on port 53/UDP. Slips marks that destination address as the DNS se
 53/udp while having DNS answers. The same heuristic applies to private IPv4 and IPv6 DNS servers. this is likely a
 DNS misconfiguration hence a FP.
 
+Slips also ignores this evidence when the checked IP is one of the DNS resolver addresses configured on the host and
+the matching DNS server port is 53. This applies to both IPv4 and IPv6 resolver addresses and covers requests sent to
+the resolver and replies coming back from it.
+
 ## High entropy DNS TXT answers
 
 Slips check every DNS answer with TXT record for high entropy

--- a/docs/flow_alerts.md
+++ b/docs/flow_alerts.md
@@ -360,6 +360,11 @@ Slips detects when a private IP is connected to another private IP with threat l
 But it skips this alert when it's a DNS or a DHCP connection on port
 53, 67 or 68 UDP to the gateway IP.
 
+Slips also skips this alert for DNS traffic on port 53 and for DHCPv6 traffic
+on ports 546 and 547. When Slips sees a private DNS flow in the analyzed
+traffic, it records that destination address as a DNS server and prints it to
+the display and to slips.log.
+
 ## Connection to private IPs outside the current local network
 
 Slips detects the currently used local network and alerts if it find a
@@ -380,13 +385,19 @@ because it's unlikely.
 and high if the destination ip is the one outside of local network.
 
 Slips ignores evidence of this type when the destination IP is a private IP outside of local network and is
-communicating on port 53/UDP. Slips marks that destination address as the DNS server when 5 flows are seen using port
-53/udp while having DNS answers. The same heuristic applies to private IPv4 and IPv6 DNS servers. this is likely a
-DNS misconfiguration hence a FP.
+communicating on port 53/UDP. Slips marks that destination address as the DNS server as soon as it sees a private
+DNS flow in `dns.log` and prints `Detected DNS server by traffic heuristic: <ip>` to the display and `slips.log`.
+The same heuristic applies to private IPv4 and IPv6 DNS servers. this is likely a DNS misconfiguration hence a FP.
 
-Slips also ignores this evidence when the checked IP is one of the DNS resolver addresses configured on the host and
-the matching DNS server port is 53. This applies to both IPv4 and IPv6 resolver addresses and covers requests sent to
-the resolver and replies coming back from it.
+Slips also ignores this evidence when the checked IP is one of the DNS
+servers detected from the analyzed DNS traffic and the matching DNS server
+port is 53. This applies to both IPv4 and IPv6 resolver addresses and
+covers requests sent to the resolver and replies coming back from it.
+
+For `CONNECTION_TO_PRIVATE_IP`, Slips suppresses DHCPv6 traffic on ports 546
+and 547. This avoids false positives when the same local network device
+provides both DNS and DHCPv6 services but answers with a different IPv6
+address, such as a link-local address.
 
 ## High entropy DNS TXT answers
 

--- a/docs/flow_alerts.md
+++ b/docs/flow_alerts.md
@@ -381,7 +381,8 @@ and high if the destination ip is the one outside of local network.
 
 Slips ignores evidence of this type when the destination IP is a private IP outside of local network and is
 communicating on port 53/UDP. Slips marks that destination address as the DNS server when 5 flows are seen using port
-53/udp while having DNS answers. this is likely a DNS misconfiguration hence a FP.
+53/udp while having DNS answers. The same heuristic applies to private IPv4 and IPv6 DNS servers. this is likely a
+DNS misconfiguration hence a FP.
 
 ## High entropy DNS TXT answers
 

--- a/modules/flow_alerts/conn.py
+++ b/modules/flow_alerts/conn.py
@@ -805,6 +805,11 @@ class Conn(IFlowalertsAnalyzer):
         if not self.should_check_diff_localnet(flow):
             return
 
+        if self.should_ignore_different_localnet_for_official_dns_server(
+            flow, what_to_check
+        ):
+            return
+
         ip_to_check = flow.saddr if what_to_check == "srcip" else flow.daddr
         if self._is_ok_to_connect_to_ip_outside_localnet(ip_to_check):
             return

--- a/modules/flow_alerts/conn.py
+++ b/modules/flow_alerts/conn.py
@@ -744,12 +744,11 @@ class Conn(IFlowalertsAnalyzer):
         """
         ip_obj = ipaddress.ip_address(ip)
         return (
-            # because slips only knows about the ipv4 local networks
-            not validators.ipv4(ip)
-            or ip in SPECIAL_IPV4
+            (ip_obj.version == 4 and ip in SPECIAL_IPV4)
             or not ip_obj.is_private
             or ip_obj.is_loopback
             or ip_obj.is_multicast
+            or ip_obj.is_link_local
         )
 
     def _is_dns(self, flow) -> bool:
@@ -765,18 +764,23 @@ class Conn(IFlowalertsAnalyzer):
             # dns flows are checked fot this same detection in dns.py
             return False
 
-        for ip in (flow.saddr, flow.daddr):
-            ip_obj = ipaddress.ip_address(ip)
-            if (
-                not validators.ipv4(ip)
-                or ip in SPECIAL_IPV4
-                or ip_obj.is_loopback
-                or ip_obj.is_multicast
-            ):
-                return False
-
         saddr_obj = ipaddress.ip_address(flow.saddr)
         daddr_obj = ipaddress.ip_address(flow.daddr)
+
+        if saddr_obj.version != daddr_obj.version:
+            return False
+
+        for ip, ip_obj in (
+            (flow.saddr, saddr_obj),
+            (flow.daddr, daddr_obj),
+        ):
+            if (
+                (ip_obj.version == 4 and ip in SPECIAL_IPV4)
+                or ip_obj.is_loopback
+                or ip_obj.is_multicast
+                or ip_obj.is_link_local
+            ):
+                return False
 
         is_saddr_private = utils.is_private_ip(saddr_obj)
         is_daddr_private = utils.is_private_ip(daddr_obj)
@@ -813,8 +817,14 @@ class Conn(IFlowalertsAnalyzer):
             # any msg is published in the new_flow channel
             return
 
-        # if it's a private ipv4 addr, it should belong to our local network
-        if ip_obj in ipaddress.IPv4Network(own_local_network):
+        own_local_network_obj = ipaddress.ip_network(
+            own_local_network, strict=False
+        )
+        if own_local_network_obj.version != ip_obj.version:
+            return
+
+        # if it's a private address, it should belong to our local network
+        if ip_obj in own_local_network_obj:
             return
 
         self.set_evidence.different_localnet_usage(

--- a/modules/flow_alerts/conn.py
+++ b/modules/flow_alerts/conn.py
@@ -4,13 +4,18 @@ import asyncio
 import contextlib
 import ipaddress
 import json
-from datetime import datetime
 from typing import Tuple, List, Dict, Any
 import validators
 
 from modules.flow_alerts.dns import DNS
 from modules.flow_alerts.utils import (
-    should_ignore_different_localnet_for_official_dns_server,
+    SPECIAL_IPV4,
+    get_ip_to_check,
+    is_interface_timeout_reached as has_interface_timeout_reached,
+    is_ip_allowed_outside_localnet,
+    is_ip_outside_local_network,
+    is_official_dns_server,
+    should_check_different_localnet,
     should_ignore_dns_or_dhcpv6_flow,
 )
 from slips_files.common.abstracts.iflowalerts_analyzer import (
@@ -24,7 +29,6 @@ from slips_files.common.input_type import InputType
 
 NOT_ESTAB = "Not Established"
 ESTAB = "Established"
-SPECIAL_IPV4 = ("0.0.0.0", "255.255.255.255")
 
 
 class Conn(IFlowalertsAnalyzer):
@@ -565,22 +569,6 @@ class Conn(IFlowalertsAnalyzer):
             pass
         return False
 
-    def is_interface_timeout_reached(self) -> bool:
-        """
-        To avoid false positives in case of an interface
-        don't alert ConnectionWithoutDNS until 30 minutes has passed after
-        starting slips because the dns may have happened before starting slips
-        """
-        if not self.is_running_non_stop:
-            # no timeout
-            return True
-
-        start_time = self.db.get_slips_start_time()
-        now = datetime.now()
-        diff = utils.get_time_diff(start_time, now, return_type="minutes")
-        # 30 minutes have passed?
-        return diff >= self.conn_without_dns_interface_wait_time
-
     async def check_connection_without_dns_resolution(
         self, profileid, twid, flow
     ) -> bool:
@@ -591,7 +579,14 @@ class Conn(IFlowalertsAnalyzer):
         if self.should_ignore_conn_without_dns(flow):
             return False
 
-        if not self.is_interface_timeout_reached():
+        if not has_interface_timeout_reached(
+            self.db,
+            self.is_running_non_stop,
+            self.conn_without_dns_interface_wait_time,
+        ):
+            # To avoid false positives in case of an interface
+            # don't alert ConnectionWithoutDNS until 30 minutes has passed after
+            # starting slips because the dns may have happened before starting slips
             return False
 
         # search 24hs back for a dns resolution
@@ -741,57 +736,13 @@ class Conn(IFlowalertsAnalyzer):
                     return True
             return False
 
-    def _is_ok_to_connect_to_ip_outside_localnet(self, ip) -> bool:
-        """
-        returns true if it's ok to connect to the given IP even if it's
-        "outside the given local network"
-        """
-        ip_obj = ipaddress.ip_address(ip)
-        return (
-            (ip_obj.version == 4 and ip in SPECIAL_IPV4)
-            or not ip_obj.is_private
-            or ip_obj.is_loopback
-            or ip_obj.is_multicast
-            or ip_obj.is_link_local
-        )
-
-    def _is_dns(self, flow) -> bool:
-        return str(flow.dport) == "53" and flow.proto.lower() == "udp"
-
-    def should_check_diff_localnet(self, flow) -> bool:
+    def should_check_diff_localnet(self, flow: Any) -> bool:
         """
         returns true when it's a non-dns flow where
         1. both ips are private
         2. the flow is from a public ip -> a private ip
         """
-        if self._is_dns(flow):
-            # dns flows are checked fot this same detection in dns.py
-            return False
-
-        saddr_obj = ipaddress.ip_address(flow.saddr)
-        daddr_obj = ipaddress.ip_address(flow.daddr)
-
-        if saddr_obj.version != daddr_obj.version:
-            return False
-
-        for ip, ip_obj in (
-            (flow.saddr, saddr_obj),
-            (flow.daddr, daddr_obj),
-        ):
-            if (
-                (ip_obj.version == 4 and ip in SPECIAL_IPV4)
-                or ip_obj.is_loopback
-                or ip_obj.is_multicast
-                or ip_obj.is_link_local
-            ):
-                return False
-
-        is_saddr_private = utils.is_private_ip(saddr_obj)
-        is_daddr_private = utils.is_private_ip(daddr_obj)
-
-        return (is_saddr_private and is_daddr_private) or (
-            not is_saddr_private and is_daddr_private
-        )
+        return should_check_different_localnet(flow, skip_dns_flows=True)
 
     def check_different_localnet_usage(self, twid, flow, what_to_check=""):
         """
@@ -809,31 +760,14 @@ class Conn(IFlowalertsAnalyzer):
         if not self.should_check_diff_localnet(flow):
             return
 
-        if should_ignore_different_localnet_for_official_dns_server(
-            self.db, flow, what_to_check
-        ):
+        if is_official_dns_server(self.db, flow, what_to_check):
             return
 
-        ip_to_check = flow.saddr if what_to_check == "srcip" else flow.daddr
-        if self._is_ok_to_connect_to_ip_outside_localnet(ip_to_check):
+        ip_to_check = get_ip_to_check(flow, what_to_check)
+        if is_ip_allowed_outside_localnet(ip_to_check):
             return
 
-        ip_obj = ipaddress.ip_address(ip_to_check)
-        own_local_network = self.db.get_local_network(flow.interface)
-        if not own_local_network:
-            # the current local network wasn't set in the db yet
-            # it's impossible to get here because the localnet is set before
-            # any msg is published in the new_flow channel
-            return
-
-        own_local_network_obj = ipaddress.ip_network(
-            own_local_network, strict=False
-        )
-        if own_local_network_obj.version != ip_obj.version:
-            return
-
-        # if it's a private address, it should belong to our local network
-        if ip_obj in own_local_network_obj:
+        if not is_ip_outside_local_network(self.db, flow, ip_to_check):
             return
 
         self.set_evidence.different_localnet_usage(

--- a/modules/flow_alerts/conn.py
+++ b/modules/flow_alerts/conn.py
@@ -841,15 +841,8 @@ class Conn(IFlowalertsAnalyzer):
     def check_connection_to_local_ip(self, twid, flow):
         """
         Alerts when there's a connection from a private IP to
-        another private IP except for DNS connections to the gateway
+        another private IP except for expected DNS and DHCP service traffic.
         """
-
-        def is_dns_conn(flow):
-            return (
-                flow.dport == 53
-                and flow.proto.lower() == "udp"
-                and flow.daddr == self.db.get_gateway_ip(flow.interface)
-            )
 
         def is_dhcp_conn(flow):
             # Bootstrap protocol server. Used by DHCP servers to communicate
@@ -862,9 +855,16 @@ class Conn(IFlowalertsAnalyzer):
 
         with contextlib.suppress(ValueError):
             flow.dport = int(flow.dport)
+        with contextlib.suppress(ValueError):
+            flow.sport = int(flow.sport)
 
-        if is_dns_conn(flow) or is_dhcp_conn(flow):
-            # skip DNS conns to the gw to avoid having tons of this evidence
+        if is_dhcp_conn(flow):
+            # skip DHCP conns to avoid having tons of this evidence
+            return
+
+        if self.should_ignore_conn_to_private_ip_for_official_dns_server(flow):
+            # skip DNS and DHCPv6 service traffic that matches the
+            # detected local resolver behavior
             return
 
         # make sure the 2 ips are private

--- a/modules/flow_alerts/conn.py
+++ b/modules/flow_alerts/conn.py
@@ -9,6 +9,10 @@ from typing import Tuple, List, Dict, Any
 import validators
 
 from modules.flow_alerts.dns import DNS
+from modules.flow_alerts.utils import (
+    should_ignore_different_localnet_for_official_dns_server,
+    should_ignore_dns_or_dhcpv6_flow,
+)
 from slips_files.common.abstracts.iflowalerts_analyzer import (
     IFlowalertsAnalyzer,
 )
@@ -805,8 +809,8 @@ class Conn(IFlowalertsAnalyzer):
         if not self.should_check_diff_localnet(flow):
             return
 
-        if self.should_ignore_different_localnet_for_official_dns_server(
-            flow, what_to_check
+        if should_ignore_different_localnet_for_official_dns_server(
+            self.db, flow, what_to_check
         ):
             return
 
@@ -862,7 +866,7 @@ class Conn(IFlowalertsAnalyzer):
             # skip DHCP conns to avoid having tons of this evidence
             return
 
-        if self.should_ignore_conn_to_private_ip_for_official_dns_server(flow):
+        if should_ignore_dns_or_dhcpv6_flow(self.db, flow):
             # skip DNS and DHCPv6 service traffic that matches the
             # detected local resolver behavior
             return

--- a/modules/flow_alerts/dns.py
+++ b/modules/flow_alerts/dns.py
@@ -645,21 +645,27 @@ class DNS(IFlowalertsAnalyzer):
         returns true if it's ok to connect to the given IP even if it's
         "outside the given local network"
         """
-        for ip in (flow.saddr, flow.daddr):
-            ip_obj = ipaddress.ip_address(ip)
+        saddr_obj = ipaddress.ip_address(flow.saddr)
+        daddr_obj = ipaddress.ip_address(flow.daddr)
+
+        if saddr_obj.version != daddr_obj.version:
+            return False
+
+        for ip, ip_obj in (
+            (flow.saddr, saddr_obj),
+            (flow.daddr, daddr_obj),
+        ):
             if (
                 # if the ip is the dns server that slips detected,
                 # it's ok to connect to it
                 ip == self.detected_dns_ip
-                or not validators.ipv4(ip)
-                or ip in SPECIAL_IPV4
+                or (ip_obj.version == 4 and ip in SPECIAL_IPV4)
                 or ip_obj.is_loopback
                 or ip_obj.is_multicast
+                or ip_obj.is_link_local
             ):
                 return False
 
-        saddr_obj = ipaddress.ip_address(flow.saddr)
-        daddr_obj = ipaddress.ip_address(flow.daddr)
         is_saddr_private = utils.is_private_ip(saddr_obj)
         is_daddr_private = utils.is_private_ip(daddr_obj)
 
@@ -708,8 +714,14 @@ class DNS(IFlowalertsAnalyzer):
             # any msg is published in the new_flow channel
             return
 
-        # if it's a private ipv4 addr, it should belong to our local network
-        if ip_obj in ipaddress.IPv4Network(own_local_network):
+        own_local_network_obj = ipaddress.ip_network(
+            own_local_network, strict=False
+        )
+        if own_local_network_obj.version != ip_obj.version:
+            return
+
+        # if it's a private address, it should belong to our local network
+        if ip_obj in own_local_network_obj:
             return
 
         self.set_evidence.different_localnet_usage(

--- a/modules/flow_alerts/dns.py
+++ b/modules/flow_alerts/dns.py
@@ -591,44 +591,11 @@ class DNS(IFlowalertsAnalyzer):
     def _is_dns(self, flow) -> bool:
         return str(flow.dport) == "53" and flow.proto.lower() == "udp"
 
-    def register_private_dns_server(self, flow) -> bool:
-        """
-        Store and announce a private DNS server seen in analyzed DNS traffic.
-
-        Parameters:
-        flow: DNS flow-like object containing the resolver destination IP.
-
-        Return:
-        bool: True when the destination IP was accepted as a private DNS
-        server, False otherwise.
-        """
-        if not self._is_dns(flow):
-            return False
-
-        try:
-            daddr_obj = ipaddress.ip_address(flow.daddr)
-        except ValueError:
-            return False
-
-        if not utils.is_private_ip(daddr_obj):
-            return False
-
-        if self.db.is_official_dns_server(flow.daddr):
-            self.detected_dns_ip = flow.daddr
-            return True
-
-        self.detected_dns_ip = flow.daddr
-        self.db.store_official_dns_server(flow.daddr)
-        self.flowalerts.print(
-            f"Detected DNS server by traffic heuristic: {flow.daddr}"
-        )
-        return True
-
     def is_possible_dns_misconfiguration(self, ip_to_check, flow) -> bool:
         """
         to avoid fps that happen when a DNS is configured using a private
         IP that's outside of localnet,
-        we detect the dns ip as follows:
+        ip_info detects the dns ip as follows:
          - if a private DNS flow using port 53/udp is seen in dns.log.
         once detected we dont alert "conn to priv ip outside of localnetwork"
         to that ip+port+proto. this is not very common but it happens when
@@ -638,10 +605,10 @@ class DNS(IFlowalertsAnalyzer):
         local network" evidence is discarded.
         """
         if ip_to_check != flow.daddr:
-            # we only register the destination of the DNS flow as the server
+            # only the destination of the DNS flow can be the resolver here
             return False
 
-        return self.register_private_dns_server(flow)
+        return self.db.is_official_dns_server(ip_to_check)
 
     def _is_ok_to_connect_to_ip_outside_localnet(self, flow) -> bool:
         """
@@ -788,7 +755,6 @@ class DNS(IFlowalertsAnalyzer):
             self.check_dns_without_connection, profileid, twid, flow
         )
 
-        self.register_private_dns_server(flow)
         self.check_high_entropy_dns_answers(twid, flow)
         self.check_invalid_dns_answers(twid, flow)
         self.detect_dga(profileid, twid, flow)

--- a/modules/flow_alerts/dns.py
+++ b/modules/flow_alerts/dns.py
@@ -6,7 +6,6 @@ import json
 import math
 import queue
 import time
-from datetime import datetime
 from typing import (
     List,
     Tuple,
@@ -18,7 +17,12 @@ from threading import Thread, Event
 
 
 from modules.flow_alerts.utils import (
-    should_ignore_different_localnet_for_official_dns_server,
+    get_ip_to_check,
+    is_dns_flow,
+    is_interface_timeout_reached as has_interface_timeout_reached,
+    is_ip_outside_local_network,
+    is_official_dns_server,
+    should_check_different_localnet,
 )
 from slips_files.common.abstracts.iflowalerts_analyzer import (
     IFlowalertsAnalyzer,
@@ -27,9 +31,6 @@ from slips_files.common.flow_classifier import FlowClassifier
 from slips_files.common.parsers.config_parser import ConfigParser
 from slips_files.common.slips_utils import utils
 from slips_files.core.structures.evidence import Direction
-
-
-SPECIAL_IPV4 = ("0.0.0.0", "255.255.255.255")
 
 
 class DNS(IFlowalertsAnalyzer):
@@ -253,22 +254,6 @@ class DNS(IFlowalertsAnalyzer):
             # this is not a DNS without resolution
             return True
 
-    def is_interface_timeout_reached(self):
-        """
-        To avoid false positives in case of an interface
-        don't alert ConnectionWithoutDNS until 30 minutes has passed after
-        starting slips because the dns may have happened before starting slips
-        """
-        if not self.is_running_non_stop:
-            # no timeout
-            return True
-
-        start_time = self.db.get_slips_start_time()
-        now = datetime.now()
-        diff = utils.get_time_diff(start_time, now, return_type="minutes")
-        # 30 minutes have passed?
-        return diff >= self.dns_without_conn_interface_wait_time
-
     def check_dns_without_connection_of_all_pending_flows(self):
         """should be called before shutting down, to check all the pending
         flows in the pending_dns_without_conn queue before stopping slips,
@@ -407,7 +392,14 @@ class DNS(IFlowalertsAnalyzer):
         if not self.should_detect_dns_without_conn(flow):
             return False
 
-        if not self.is_interface_timeout_reached():
+        if not has_interface_timeout_reached(
+            self.db,
+            self.is_running_non_stop,
+            self.dns_without_conn_interface_wait_time,
+        ):
+            # To avoid false positives in case of an interface
+            # don't alert ConnectionWithoutDNS until 30 minutes has passed after
+            # starting slips because the dns may have happened before starting slips
             return False
 
         if self.is_any_flow_answer_contacted(profileid, twid, flow):
@@ -591,9 +583,6 @@ class DNS(IFlowalertsAnalyzer):
         self.dns_arpa_queries.pop(profileid)
         return True
 
-    def _is_dns(self, flow) -> bool:
-        return str(flow.dport) == "53" and flow.proto.lower() == "udp"
-
     def is_possible_dns_misconfiguration(self, ip_to_check, flow) -> bool:
         """
         to avoid fps that happen when a DNS is configured using a private
@@ -613,39 +602,6 @@ class DNS(IFlowalertsAnalyzer):
 
         return self.db.is_official_dns_server(ip_to_check)
 
-    def _is_ok_to_connect_to_ip_outside_localnet(self, flow) -> bool:
-        """
-        returns true if it's ok to connect to the given IP even if it's
-        "outside the given local network"
-        """
-        saddr_obj = ipaddress.ip_address(flow.saddr)
-        daddr_obj = ipaddress.ip_address(flow.daddr)
-
-        if saddr_obj.version != daddr_obj.version:
-            return False
-
-        for ip, ip_obj in (
-            (flow.saddr, saddr_obj),
-            (flow.daddr, daddr_obj),
-        ):
-            if (
-                # if the ip is the dns server that slips detected,
-                # it's ok to connect to it
-                self.db.is_official_dns_server(ip)
-                or (ip_obj.version == 4 and ip in SPECIAL_IPV4)
-                or ip_obj.is_loopback
-                or ip_obj.is_multicast
-                or ip_obj.is_link_local
-            ):
-                return False
-
-        is_saddr_private = utils.is_private_ip(saddr_obj)
-        is_daddr_private = utils.is_private_ip(daddr_obj)
-
-        return (is_saddr_private and is_daddr_private) or (
-            not is_saddr_private and is_daddr_private
-        )
-
     def check_different_localnet_usage(
         self,
         twid,
@@ -662,19 +618,21 @@ class DNS(IFlowalertsAnalyzer):
 
         only checks connections to dst port 53/UDP. the rest are checked in conn.log
         """
-        if not self._is_dns(flow):
+        if not is_dns_flow(flow):
             # the non dns flows are checked in conn.py
             return
 
-        if should_ignore_different_localnet_for_official_dns_server(
-            self.db, flow, what_to_check
+        if is_official_dns_server(self.db, flow, what_to_check):
+            return
+
+        if should_check_different_localnet(
+            flow,
+            db=self.db,
+            ignore_official_dns_servers=True,
         ):
             return
 
-        if self._is_ok_to_connect_to_ip_outside_localnet(flow):
-            return
-
-        ip_to_check = flow.saddr if what_to_check == "srcip" else flow.daddr
+        ip_to_check = get_ip_to_check(flow, what_to_check)
 
         ip_obj = ipaddress.ip_address(ip_to_check)
         if not (utils.is_private_ip(ip_obj)):
@@ -685,22 +643,7 @@ class DNS(IFlowalertsAnalyzer):
             # outside of localnet
             return
 
-        own_local_network = self.db.get_local_network(flow.interface)
-        if not own_local_network:
-            # the current local network wasn't set in the db yet
-            # it's impossible to get here becaus ethe localnet is set before
-            # any msg is published in the new_flow channel
-            return
-
-        own_local_network_obj = ipaddress.ip_network(
-            own_local_network, strict=False
-        )
-        if own_local_network_obj.version != ip_obj.version:
-            # both should be ipv6 or ipv4
-            return
-
-        # if it's a private address, it should belong to our local network
-        if ip_obj in own_local_network_obj:
+        if not is_ip_outside_local_network(self.db, flow, ip_to_check):
             return
 
         self.set_evidence.different_localnet_usage(

--- a/modules/flow_alerts/dns.py
+++ b/modules/flow_alerts/dns.py
@@ -693,6 +693,11 @@ class DNS(IFlowalertsAnalyzer):
             # the non dns flows are checked in conn.py
             return
 
+        if self.should_ignore_different_localnet_for_official_dns_server(
+            flow, what_to_check
+        ):
+            return
+
         if self._is_ok_to_connect_to_ip_outside_localnet(flow):
             return
 

--- a/modules/flow_alerts/dns.py
+++ b/modules/flow_alerts/dns.py
@@ -17,6 +17,9 @@ from multiprocessing import Queue
 from threading import Thread, Event
 
 
+from modules.flow_alerts.utils import (
+    should_ignore_different_localnet_for_official_dns_server,
+)
 from slips_files.common.abstracts.iflowalerts_analyzer import (
     IFlowalertsAnalyzer,
 )
@@ -663,8 +666,8 @@ class DNS(IFlowalertsAnalyzer):
             # the non dns flows are checked in conn.py
             return
 
-        if self.should_ignore_different_localnet_for_official_dns_server(
-            flow, what_to_check
+        if should_ignore_different_localnet_for_official_dns_server(
+            self.db, flow, what_to_check
         ):
             return
 
@@ -693,6 +696,7 @@ class DNS(IFlowalertsAnalyzer):
             own_local_network, strict=False
         )
         if own_local_network_obj.version != ip_obj.version:
+            # both should be ipv6 or ipv4
             return
 
         # if it's a private address, it should belong to our local network

--- a/modules/flow_alerts/dns.py
+++ b/modules/flow_alerts/dns.py
@@ -64,8 +64,6 @@ class DNS(IFlowalertsAnalyzer):
         # meaning, only flow_alerts.py is allowed to do a get_msg because it
         # manages all the analyzers the msg should be passed to
         self.dns_msgs = Queue()
-        self.priv_ips_doing_dns_outside_of_localnet = {}
-        self.is_dns_detected = False
         self.detected_dns_ip = "-"
 
     def name(self) -> str:
@@ -593,52 +591,57 @@ class DNS(IFlowalertsAnalyzer):
     def _is_dns(self, flow) -> bool:
         return str(flow.dport) == "53" and flow.proto.lower() == "udp"
 
+    def register_private_dns_server(self, flow) -> bool:
+        """
+        Store and announce a private DNS server seen in analyzed DNS traffic.
+
+        Parameters:
+        flow: DNS flow-like object containing the resolver destination IP.
+
+        Return:
+        bool: True when the destination IP was accepted as a private DNS
+        server, False otherwise.
+        """
+        if not self._is_dns(flow):
+            return False
+
+        try:
+            daddr_obj = ipaddress.ip_address(flow.daddr)
+        except ValueError:
+            return False
+
+        if not utils.is_private_ip(daddr_obj):
+            return False
+
+        if self.db.is_official_dns_server(flow.daddr):
+            self.detected_dns_ip = flow.daddr
+            return True
+
+        self.detected_dns_ip = flow.daddr
+        self.db.store_official_dns_server(flow.daddr)
+        self.flowalerts.print(
+            f"Detected DNS server by traffic heuristic: {flow.daddr}"
+        )
+        return True
+
     def is_possible_dns_misconfiguration(self, ip_to_check, flow) -> bool:
         """
         to avoid fps that happen when a DNS is configured using a private
         IP that's outside of localnet,
         we detect the dns ip as follows:
-         - if 5 conns with dns answers on port 53/udp.
-        once detected and we dont alert "conn to priv ip outside of
-        localnetwork" to that ip+port+proto
-        this is not very common but it happens when the dns is misconfigured
+         - if a private DNS flow using port 53/udp is seen in dns.log.
+        once detected we dont alert "conn to priv ip outside of localnetwork"
+        to that ip+port+proto. this is not very common but it happens when
+        the dns is misconfigured.
 
         When this returns True, the "conn to priv ip outside of
         local network" evidence is discarded.
         """
         if ip_to_check != flow.daddr:
-            # we need 5 conns to the possible dns server to be able to
-            # officialy ignore evidence to it. we dont need to check src
-            # addresses
+            # we only register the destination of the DNS flow as the server
             return False
 
-        if self.is_dns_detected:
-            # we already detected the dns using this function.
-            # disable this function, we'll be using the detected dns in
-            # _is_ok_to_connect_to_ip()
-            return False
-
-        if not flow.answers:
-            # dns ips should only be detected using dns flows with answers
-            return False
-
-        try:
-            self.priv_ips_doing_dns_outside_of_localnet[flow.daddr] += 1
-            if self.priv_ips_doing_dns_outside_of_localnet[flow.daddr] == 5:
-                # this ip probably a dns server
-                self.is_dns_detected = True
-                self.detected_dns_ip = flow.daddr
-                del self.priv_ips_doing_dns_outside_of_localnet
-            # if we have less than 5 dns connections with answers,
-            # wait more.
-            # but do not alert bc it will probably be a fp.
-            # wait until we get 5 conns with dns answers to that ip
-
-            return True
-
-        except KeyError:
-            self.priv_ips_doing_dns_outside_of_localnet[flow.daddr] = 1
-            return True
+        return self.register_private_dns_server(flow)
 
     def _is_ok_to_connect_to_ip_outside_localnet(self, flow) -> bool:
         """
@@ -658,7 +661,7 @@ class DNS(IFlowalertsAnalyzer):
             if (
                 # if the ip is the dns server that slips detected,
                 # it's ok to connect to it
-                ip == self.detected_dns_ip
+                self.db.is_official_dns_server(ip)
                 or (ip_obj.version == 4 and ip in SPECIAL_IPV4)
                 or ip_obj.is_loopback
                 or ip_obj.is_multicast
@@ -785,6 +788,7 @@ class DNS(IFlowalertsAnalyzer):
             self.check_dns_without_connection, profileid, twid, flow
         )
 
+        self.register_private_dns_server(flow)
         self.check_high_entropy_dns_answers(twid, flow)
         self.check_invalid_dns_answers(twid, flow)
         self.detect_dga(profileid, twid, flow)

--- a/modules/flow_alerts/utils.py
+++ b/modules/flow_alerts/utils.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Garcia <sebastian.garcia@agents.fel.cvut.cz>
+# SPDX-License-Identifier: GPL-2.0-only
+from typing import Any
+
+from slips_files.core.database.database_manager import DBManager
+
+DHCPV6_PORTS = {"546", "547"}
+
+
+def should_ignore_different_localnet_for_official_dns_server(
+    db: DBManager,
+    flow: Any,
+    what_to_check: str,
+) -> bool:
+    """
+    Check whether different-localnet evidence should be skipped.
+
+    Parameters:
+    db: Database manager used to check known official DNS servers.
+    flow: Flow-like object being analyzed.
+    what_to_check: IP direction being evaluated, either srcip or dstip.
+
+    Return:
+    bool: True when the checked IP is a detected DNS server using port 53.
+    """
+    if what_to_check == "dstip":
+        dns_server_ip = getattr(flow, "daddr", "")
+        dns_server_port = getattr(flow, "dport", "")
+    elif what_to_check == "srcip":
+        dns_server_ip = getattr(flow, "saddr", "")
+        dns_server_port = getattr(flow, "sport", "")
+    else:
+        return False
+
+    if str(dns_server_port) != "53" or not dns_server_ip:
+        return False
+
+    return db.is_official_dns_server(dns_server_ip)
+
+
+def should_ignore_dns_or_dhcpv6_flow(
+    db: DBManager,
+    flow: Any,
+) -> bool:
+    """
+    Check whether private-IP connection evidence should be skipped.
+
+    Parameters:
+    db: Database manager used to check known official DNS servers.
+    flow: Flow-like object being analyzed.
+
+    Return:
+    bool: True when the flow is a DNS query to port 53, a DNS reply from a
+    detected DNS server, or DHCPv6 service traffic.
+    """
+    if getattr(flow, "proto", "").lower() != "udp":
+        return False
+
+    daddr = getattr(flow, "daddr", "")
+    saddr = getattr(flow, "saddr", "")
+    dport = str(getattr(flow, "dport", ""))
+    sport = str(getattr(flow, "sport", ""))
+
+    if dport == "53" and daddr:
+        return True
+
+    if sport == "53" and saddr and db.is_official_dns_server(saddr):
+        return True
+
+    if sport in DHCPV6_PORTS or dport in DHCPV6_PORTS:
+        return True
+
+    return False

--- a/modules/flow_alerts/utils.py
+++ b/modules/flow_alerts/utils.py
@@ -1,27 +1,199 @@
 # SPDX-FileCopyrightText: 2021 Sebastian Garcia <sebastian.garcia@agents.fel.cvut.cz>
 # SPDX-License-Identifier: GPL-2.0-only
 from typing import Any
+import ipaddress
+from datetime import datetime
 
+from slips_files.common.slips_utils import utils
 from slips_files.core.database.database_manager import DBManager
 
 DHCPV6_PORTS = {"546", "547"}
+SPECIAL_IPV4 = ("0.0.0.0", "255.255.255.255")
 
 
-def should_ignore_different_localnet_for_official_dns_server(
+def get_ip_to_check(flow: Any, what_to_check: str) -> str:
+    """
+    Get the source or destination IP selected by the check direction.
+
+    Parameters:
+    flow: Flow-like object being analyzed.
+    what_to_check: IP direction being evaluated, either srcip or dstip.
+
+    Return:
+    str: Selected IP address, or an empty string for unsupported directions.
+    """
+    if what_to_check == "srcip":
+        return getattr(flow, "saddr", "")
+    if what_to_check == "dstip":
+        return getattr(flow, "daddr", "")
+    return ""
+
+
+def is_dns_flow(flow: Any) -> bool:
+    """
+    Check whether a flow is DNS traffic to destination port 53/UDP.
+
+    Parameters:
+    flow: Flow-like object being analyzed.
+
+    Return:
+    bool: True when the flow is DNS traffic.
+    """
+    return (
+        str(getattr(flow, "dport", "")) == "53"
+        and getattr(flow, "proto", "").lower() == "udp"
+    )
+
+
+def is_ignored_localnet_ip(
+    ip: str,
+    ip_obj: ipaddress.IPv4Address | ipaddress.IPv6Address | None = None,
+) -> bool:
+    """
+    Check whether an IP should be skipped for local-network evidence.
+
+    Parameters:
+    ip: IP address string.
+    ip_obj: Parsed IP address object, if the caller already has one.
+
+    Return:
+    bool: True for special IPv4, loopback, multicast, or link-local IPs.
+    """
+    ip_obj = ip_obj or ipaddress.ip_address(ip)
+    return (
+        (ip_obj.version == 4 and ip in SPECIAL_IPV4)
+        or ip_obj.is_loopback
+        or ip_obj.is_multicast
+        or ip_obj.is_link_local
+    )
+
+
+def is_ip_allowed_outside_localnet(ip: str) -> bool:
+    """
+    Check whether an IP is expected outside the configured local network.
+
+    Parameters:
+    ip: IP address string.
+
+    Return:
+    bool: True when different-localnet evidence should be skipped for this IP.
+    """
+    ip_obj = ipaddress.ip_address(ip)
+    return is_ignored_localnet_ip(ip, ip_obj) or not ip_obj.is_private
+
+
+def should_check_different_localnet(
+    flow: Any,
+    db: DBManager | None = None,
+    skip_dns_flows: bool = False,
+    ignore_official_dns_servers: bool = False,
+) -> bool:
+    """
+    Check whether a flow is eligible for different-localnet detection.
+
+    Parameters:
+    flow: Flow-like object being analyzed.
+    db: Database manager used when official DNS servers should be skipped.
+    skip_dns_flows: Skip DNS flows because another analyzer handles them.
+    ignore_official_dns_servers: Skip flows involving detected DNS servers.
+
+    Return:
+    bool: True when the flow has private-to-private or public-to-private
+    addresses that should be compared with the configured local network.
+    """
+    if skip_dns_flows and is_dns_flow(flow):
+        return False
+
+    saddr = getattr(flow, "saddr", "")
+    daddr = getattr(flow, "daddr", "")
+    saddr_obj = ipaddress.ip_address(saddr)
+    daddr_obj = ipaddress.ip_address(daddr)
+
+    if saddr_obj.version != daddr_obj.version:
+        return False
+
+    for ip, ip_obj in ((saddr, saddr_obj), (daddr, daddr_obj)):
+        if (
+            ignore_official_dns_servers
+            and db
+            and db.is_official_dns_server(ip)
+        ):
+            return False
+
+        if is_ignored_localnet_ip(ip, ip_obj):
+            return False
+
+    is_saddr_private = utils.is_private_ip(saddr_obj)
+    is_daddr_private = utils.is_private_ip(daddr_obj)
+
+    return (is_saddr_private and is_daddr_private) or (
+        not is_saddr_private and is_daddr_private
+    )
+
+
+def is_ip_outside_local_network(
+    db: DBManager,
+    flow: Any,
+    ip_to_check: str,
+) -> bool:
+    """
+    Check whether an IP is outside the flow interface local network.
+
+    Parameters:
+    db: Database manager used to load the interface local network.
+    flow: Flow-like object containing the interface name.
+    ip_to_check: IP address to compare with the local network.
+
+    Return:
+    bool: True when the IP version matches the local network and the IP is
+    outside that network.
+    """
+    own_local_network = db.get_local_network(getattr(flow, "interface", ""))
+    if not own_local_network:
+        return False
+
+    ip_obj = ipaddress.ip_address(ip_to_check)
+    own_local_network_obj = ipaddress.ip_network(
+        own_local_network, strict=False
+    )
+    if own_local_network_obj.version != ip_obj.version:
+        return False
+
+    return ip_obj not in own_local_network_obj
+
+
+def is_interface_timeout_reached(
+    db: DBManager,
+    is_running_non_stop: bool,
+    wait_time: int | float,
+) -> bool:
+    """
+    Check whether interface startup grace time has elapsed.
+
+    Parameters:
+    db: Database manager used to get the Slips start time.
+    is_running_non_stop: True when Slips is running on an interface.
+    wait_time: Grace period in minutes.
+
+    Return:
+    bool: True when evidence can be emitted.
+    """
+    if not is_running_non_stop:
+        return True
+
+    start_time = db.get_slips_start_time()
+    now = datetime.now()
+    diff = utils.get_time_diff(start_time, now, return_type="minutes")
+    return diff >= wait_time
+
+
+def is_official_dns_server(
     db: DBManager,
     flow: Any,
     what_to_check: str,
 ) -> bool:
     """
-    Check whether different-localnet evidence should be skipped.
-
-    Parameters:
-    db: Database manager used to check known official DNS servers.
-    flow: Flow-like object being analyzed.
-    what_to_check: IP direction being evaluated, either srcip or dstip.
-
-    Return:
-    bool: True when the checked IP is a detected DNS server using port 53.
+    returns True when the checked IP is a detected DNS server using port 53.
     """
     if what_to_check == "dstip":
         dns_server_ip = getattr(flow, "daddr", "")

--- a/modules/ip_info/ip_info.py
+++ b/modules/ip_info/ip_info.py
@@ -14,7 +14,6 @@ import whois
 import socket
 import requests
 import json
-import dns.resolver
 from contextlib import redirect_stdout, redirect_stderr
 import subprocess
 import netifaces
@@ -483,34 +482,6 @@ class IPInfo(IAsyncModule):
         default = gws.get("default", {})
         return default.get(netifaces.AF_INET, (None,))[0]
 
-    @staticmethod
-    def get_configured_dns_server_ips() -> List[str]:
-        """
-        Get the configured DNS resolver IPs from the local system.
-
-        Parameters:
-        None.
-
-        Return:
-        list[str]: Valid IPv4 and IPv6 resolver addresses.
-        """
-        try:
-            resolver = dns.resolver.Resolver()
-        except dns.resolver.NoResolverConfiguration:
-            return []
-
-        dns_servers = []
-        for nameserver in resolver.nameservers:
-            nameserver = str(nameserver)
-            try:
-                ipaddress.ip_address(nameserver)
-            except ValueError:
-                continue
-
-            dns_servers.append(nameserver)
-
-        return dns_servers
-
     def get_gateway_ip_if_interface(self) -> Dict[str, str] | None:
         """
         returns the gateway ip of the given interface if running on an
@@ -816,9 +787,6 @@ class IPInfo(IAsyncModule):
             if gw_macs := self.get_gateway_mac(gw_ips):
                 for interface, gw_mac in gw_macs.items():
                     self.db.set_default_gateway("MAC", gw_mac, interface)
-
-        for dns_server in self.get_configured_dns_server_ips():
-            self.db.store_official_dns_server(dns_server)
 
     def handle_new_ip(self, ip: str):
         try:

--- a/modules/ip_info/ip_info.py
+++ b/modules/ip_info/ip_info.py
@@ -5,6 +5,7 @@ from typing import (
     Optional,
     Dict,
     List,
+    Any,
 )
 from uuid import uuid4, getnode
 import datetime
@@ -70,6 +71,7 @@ class IPInfo(IAsyncModule):
         self.is_running_non_stop: bool = self.db.is_running_non_stop()
         self.valid_tlds = frozenset(whois.validTlds())
         self.domain_validity_cache = {}
+        self.detected_dns_ip = "-"
         self.is_running_in_ap_mode: bool = (
             True if self.args.access_point else False
         )
@@ -699,6 +701,37 @@ class IPInfo(IAsyncModule):
         """
         await self.get_domain_info_async(domain)
 
+    @staticmethod
+    def _is_dns(flow: Any) -> bool:
+        return str(flow.dport) == "53" and flow.proto.lower() == "udp"
+
+    def register_private_dns_server(self, flow: Any) -> bool:
+        """
+        Store and announce a private DNS server seen in analyzed DNS traffic.
+
+        :return: True when the destination IP was accepted as a private DNS
+            server.
+        """
+        if not self._is_dns(flow):
+            return False
+
+        try:
+            daddr_obj = ipaddress.ip_address(flow.daddr)
+        except ValueError:
+            return False
+
+        if not utils.is_private_ip(daddr_obj):
+            return False
+
+        if self.db.is_official_dns_server(flow.daddr):
+            self.detected_dns_ip = flow.daddr
+            return True
+
+        self.detected_dns_ip = flow.daddr
+        self.db.store_official_dns_server(flow.daddr)
+        self.print(f"Detected DNS server by traffic heuristic: {flow.daddr}")
+        return True
+
     def wait_for_dbs(self):
         """
         wait for update manager to finish updating the mac db and open the
@@ -708,7 +741,8 @@ class IPInfo(IAsyncModule):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         # run open_dbs in the background so we don't have
-        # to wait for update manager to finish updating the mac db to start this module
+        # to wait for update manager to finish updating the mac db to start
+        # this module
         loop.run_until_complete(self.open_dbs())
 
     def set_evidence_malicious_jarm_hash(
@@ -825,6 +859,7 @@ class IPInfo(IAsyncModule):
         if msg := self.get_msg("new_dns"):
             msg = json.loads(msg["data"])
             flow = self.classifier.convert_to_flow_obj(msg["flow"])
+            self.register_private_dns_server(flow)
             if domain := flow.query:
                 self.create_task(self.handle_new_dns_async, domain)
 

--- a/modules/ip_info/ip_info.py
+++ b/modules/ip_info/ip_info.py
@@ -14,6 +14,7 @@ import whois
 import socket
 import requests
 import json
+import dns.resolver
 from contextlib import redirect_stdout, redirect_stderr
 import subprocess
 import netifaces
@@ -482,6 +483,34 @@ class IPInfo(IAsyncModule):
         default = gws.get("default", {})
         return default.get(netifaces.AF_INET, (None,))[0]
 
+    @staticmethod
+    def get_configured_dns_server_ips() -> List[str]:
+        """
+        Get the configured DNS resolver IPs from the local system.
+
+        Parameters:
+        None.
+
+        Return:
+        list[str]: Valid IPv4 and IPv6 resolver addresses.
+        """
+        try:
+            resolver = dns.resolver.Resolver()
+        except dns.resolver.NoResolverConfiguration:
+            return []
+
+        dns_servers = []
+        for nameserver in resolver.nameservers:
+            nameserver = str(nameserver)
+            try:
+                ipaddress.ip_address(nameserver)
+            except ValueError:
+                continue
+
+            dns_servers.append(nameserver)
+
+        return dns_servers
+
     def get_gateway_ip_if_interface(self) -> Dict[str, str] | None:
         """
         returns the gateway ip of the given interface if running on an
@@ -787,6 +816,9 @@ class IPInfo(IAsyncModule):
             if gw_macs := self.get_gateway_mac(gw_ips):
                 for interface, gw_mac in gw_macs.items():
                     self.db.set_default_gateway("MAC", gw_mac, interface)
+
+        for dns_server in self.get_configured_dns_server_ips():
+            self.db.store_official_dns_server(dns_server)
 
     def handle_new_ip(self, ip: str):
         try:

--- a/modules/ip_info/ip_info.py
+++ b/modules/ip_info/ip_info.py
@@ -27,6 +27,7 @@ from functools import lru_cache, partial
 
 from modules.ip_info.jarm import JARM
 from slips_files.common.flow_classifier import FlowClassifier
+from slips_files.common.style import green
 from slips_files.core.helpers.whitelist.whitelist import Whitelist
 from .asn_info import ASN
 from slips_files.common.abstracts.iasync_module import IAsyncModule
@@ -71,7 +72,6 @@ class IPInfo(IAsyncModule):
         self.is_running_non_stop: bool = self.db.is_running_non_stop()
         self.valid_tlds = frozenset(whois.validTlds())
         self.domain_validity_cache = {}
-        self.detected_dns_ip = "-"
         self.is_running_in_ap_mode: bool = (
             True if self.args.access_point else False
         )
@@ -724,12 +724,13 @@ class IPInfo(IAsyncModule):
             return False
 
         if self.db.is_official_dns_server(flow.daddr):
-            self.detected_dns_ip = flow.daddr
             return True
 
-        self.detected_dns_ip = flow.daddr
         self.db.store_official_dns_server(flow.daddr)
-        self.print(f"Detected DNS server by traffic heuristic: {flow.daddr}")
+        self.print(
+            f"Detected DNS server by traffic heuristic: "
+            f"{green(flow.daddr)}"
+        )
         return True
 
     def wait_for_dbs(self):

--- a/slips_files/common/abstracts/iflowalerts_analyzer.py
+++ b/slips_files/common/abstracts/iflowalerts_analyzer.py
@@ -33,66 +33,6 @@ class IFlowalertsAnalyzer(ABC):
     def read_configuration(self):
         """Reads configuration"""
 
-    def should_ignore_different_localnet_for_official_dns_server(
-        self, flow, what_to_check: str
-    ) -> bool:
-        """
-        Check whether different-localnet evidence should be skipped.
-
-        Parameters:
-        flow: Flow-like object being analyzed.
-        what_to_check: IP direction being evaluated, either srcip or dstip.
-
-        Return:
-        bool: True when the checked IP is a detected DNS server using
-        port 53.
-        """
-        if what_to_check == "dstip":
-            dns_server_ip = getattr(flow, "daddr", "")
-            dns_server_port = getattr(flow, "dport", "")
-        elif what_to_check == "srcip":
-            dns_server_ip = getattr(flow, "saddr", "")
-            dns_server_port = getattr(flow, "sport", "")
-        else:
-            return False
-
-        if str(dns_server_port) != "53" or not dns_server_ip:
-            return False
-
-        return self.db.is_official_dns_server(dns_server_ip)
-
-    def should_ignore_conn_to_private_ip_for_official_dns_server(
-        self, flow
-    ) -> bool:
-        """
-        Check whether private-IP connection evidence should be skipped.
-
-        Parameters:
-        flow: Flow-like object being analyzed.
-
-        Return:
-        bool: True when the flow is a DNS query to port 53, a DNS reply
-        from a detected DNS server, or DHCPv6 service traffic.
-        """
-        if getattr(flow, "proto", "").lower() != "udp":
-            return False
-
-        daddr = getattr(flow, "daddr", "")
-        saddr = getattr(flow, "saddr", "")
-        dport = str(getattr(flow, "dport", ""))
-        sport = str(getattr(flow, "sport", ""))
-
-        if dport == "53" and daddr:
-            return True
-
-        if sport == "53" and saddr and self.db.is_official_dns_server(saddr):
-            return True
-
-        if {sport, dport}.intersection({"546", "547"}):
-            return True
-
-        return False
-
     @abstractmethod
     def init(self):
         """

--- a/slips_files/common/abstracts/iflowalerts_analyzer.py
+++ b/slips_files/common/abstracts/iflowalerts_analyzer.py
@@ -33,6 +33,34 @@ class IFlowalertsAnalyzer(ABC):
     def read_configuration(self):
         """Reads configuration"""
 
+    def should_ignore_different_localnet_for_official_dns_server(
+        self, flow, what_to_check: str
+    ) -> bool:
+        """
+        Check whether different-localnet evidence should be skipped.
+
+        Parameters:
+        flow: Flow-like object being analyzed.
+        what_to_check: IP direction being evaluated, either srcip or dstip.
+
+        Return:
+        bool: True when the checked IP is a configured DNS server using
+        port 53.
+        """
+        if what_to_check == "dstip":
+            dns_server_ip = getattr(flow, "daddr", "")
+            dns_server_port = getattr(flow, "dport", "")
+        elif what_to_check == "srcip":
+            dns_server_ip = getattr(flow, "saddr", "")
+            dns_server_port = getattr(flow, "sport", "")
+        else:
+            return False
+
+        if str(dns_server_port) != "53" or not dns_server_ip:
+            return False
+
+        return self.db.is_official_dns_server(dns_server_ip)
+
     @abstractmethod
     def init(self):
         """

--- a/slips_files/common/abstracts/iflowalerts_analyzer.py
+++ b/slips_files/common/abstracts/iflowalerts_analyzer.py
@@ -44,7 +44,7 @@ class IFlowalertsAnalyzer(ABC):
         what_to_check: IP direction being evaluated, either srcip or dstip.
 
         Return:
-        bool: True when the checked IP is a configured DNS server using
+        bool: True when the checked IP is a detected DNS server using
         port 53.
         """
         if what_to_check == "dstip":
@@ -60,6 +60,38 @@ class IFlowalertsAnalyzer(ABC):
             return False
 
         return self.db.is_official_dns_server(dns_server_ip)
+
+    def should_ignore_conn_to_private_ip_for_official_dns_server(
+        self, flow
+    ) -> bool:
+        """
+        Check whether private-IP connection evidence should be skipped.
+
+        Parameters:
+        flow: Flow-like object being analyzed.
+
+        Return:
+        bool: True when the flow is a DNS query to port 53, a DNS reply
+        from a detected DNS server, or DHCPv6 service traffic.
+        """
+        if getattr(flow, "proto", "").lower() != "udp":
+            return False
+
+        daddr = getattr(flow, "daddr", "")
+        saddr = getattr(flow, "saddr", "")
+        dport = str(getattr(flow, "dport", ""))
+        sport = str(getattr(flow, "sport", ""))
+
+        if dport == "53" and daddr:
+            return True
+
+        if sport == "53" and saddr and self.db.is_official_dns_server(saddr):
+            return True
+
+        if {sport, dport}.intersection({"546", "547"}):
+            return True
+
+        return False
 
     @abstractmethod
     def init(self):

--- a/slips_files/common/slips_utils.py
+++ b/slips_files/common/slips_utils.py
@@ -118,7 +118,7 @@ class Utils(object):
     def get_cidr_of_private_ip(self, ip):
         """
         returns the cidr/range of the given private ip
-        :param ip: should be a private ipv4
+        :param ip: should be a private ipv4 or ipv6
         """
         if validators.ipv4(ip):
             first_octet = ip.split(".")[0]
@@ -127,6 +127,16 @@ class Utils(object):
             for network_range in self.home_network_ranges_str:
                 if first_octet in network_range:
                     return network_range
+        elif validators.ipv6(ip):
+            ip_obj = ipaddress.ip_address(ip)
+            if (
+                ip_obj.is_private
+                and not ip_obj.is_link_local
+                and not ip_obj.is_loopback
+                and not ip_obj.is_multicast
+                and not ip_obj.is_reserved
+            ):
+                return str(ipaddress.ip_network(f"{ip}/64", strict=False))
 
     def threat_level_to_string(self, threat_level: float) -> str:
         for str_lvl, int_value in self.threat_levels.items():

--- a/slips_files/common/slips_utils.py
+++ b/slips_files/common/slips_utils.py
@@ -128,6 +128,9 @@ class Utils(object):
                 if first_octet in network_range:
                     return network_range
         elif validators.ipv6(ip):
+            ip_obj = ipaddress.ip_address(ip)
+            if ip_obj in ipaddress.ip_network("fc00::/7"):
+                return str(ipaddress.ip_network(f"{ip}/64", strict=False))
             if not self.are_detection_modules_interested_in_this_ip(ip):
                 return str(ipaddress.ip_network(f"{ip}/64", strict=False))
 

--- a/slips_files/common/slips_utils.py
+++ b/slips_files/common/slips_utils.py
@@ -128,14 +128,7 @@ class Utils(object):
                 if first_octet in network_range:
                     return network_range
         elif validators.ipv6(ip):
-            ip_obj = ipaddress.ip_address(ip)
-            if (
-                ip_obj.is_private
-                and not ip_obj.is_link_local
-                and not ip_obj.is_loopback
-                and not ip_obj.is_multicast
-                and not ip_obj.is_reserved
-            ):
+            if not self.are_detection_modules_interested_in_this_ip(ip):
                 return str(ipaddress.ip_network(f"{ip}/64", strict=False))
 
     def threat_level_to_string(self, threat_level: float) -> str:

--- a/slips_files/core/database/database_manager.py
+++ b/slips_files/core/database/database_manager.py
@@ -755,6 +755,12 @@ class DBManager:
     def is_dhcp_server(self, *args, **kwargs):
         return self.rdb.is_dhcp_server(*args, **kwargs)
 
+    def store_official_dns_server(self, *args, **kwargs):
+        return self.rdb.store_official_dns_server(*args, **kwargs)
+
+    def is_official_dns_server(self, *args, **kwargs):
+        return self.rdb.is_official_dns_server(*args, **kwargs)
+
     def save(self, *args, **kwargs):
         return self.rdb.save(*args, **kwargs)
 

--- a/slips_files/core/database/redis_db/constants.py
+++ b/slips_files/core/database/redis_db/constants.py
@@ -40,6 +40,7 @@ class Constants:
     WHITELIST = "whitelist"
     GROWING_ZEEK_DIR = "growing_zeek_dir"
     DHCP_SERVERS = "DHCP_servers"
+    OFFICIAL_DNS_SERVERS = "official_DNS_servers"
     LABELS = "labels"
     MSGS_PUBLISHED_AT_RUNTIME = "msgs_published_at_runtime"
     ZEEK_FILES = "zeekfiles"

--- a/slips_files/core/database/redis_db/database.py
+++ b/slips_files/core/database/redis_db/database.py
@@ -1795,7 +1795,7 @@ class RedisDB(
 
     def is_official_dns_server(self, ip: str) -> bool:
         """
-        Check whether the given IP is one of the configured DNS servers.
+        Check whether the given IP is one of the detected DNS servers.
 
         Parameters:
         ip: IP address to check.
@@ -1814,7 +1814,7 @@ class RedisDB(
 
     def store_official_dns_server(self, server_addr: str):
         """
-        Store a configured DNS server IP in the database.
+        Store a detected DNS server IP in the database.
 
         Parameters:
         server_addr: DNS server IPv4 or IPv6 address.

--- a/slips_files/core/database/redis_db/database.py
+++ b/slips_files/core/database/redis_db/database.py
@@ -1796,12 +1796,6 @@ class RedisDB(
     def is_official_dns_server(self, ip: str) -> bool:
         """
         Check whether the given IP is one of the detected DNS servers.
-
-        Parameters:
-        ip: IP address to check.
-
-        Return:
-        bool: True when the IP is stored as an official DNS server.
         """
         try:
             ipaddress.ip_address(ip)
@@ -1811,12 +1805,6 @@ class RedisDB(
         return bool(self.r.sismember(self.constants.OFFICIAL_DNS_SERVERS, ip))
 
     def store_official_dns_server(self, server_addr: str):
-        """
-        Store a detected DNS server IP in the database.
-
-        Parameters:
-        server_addr: DNS server IPv4 or IPv6 address.
-        """
         try:
             ipaddress.ip_address(server_addr)
         except ValueError:

--- a/slips_files/core/database/redis_db/database.py
+++ b/slips_files/core/database/redis_db/database.py
@@ -1808,9 +1808,7 @@ class RedisDB(
         except ValueError:
             return False
 
-        return bool(
-            self.r.sismember(self.constants.OFFICIAL_DNS_SERVERS, ip)
-        )
+        return bool(self.r.sismember(self.constants.OFFICIAL_DNS_SERVERS, ip))
 
     def store_official_dns_server(self, server_addr: str):
         """
@@ -1818,9 +1816,6 @@ class RedisDB(
 
         Parameters:
         server_addr: DNS server IPv4 or IPv6 address.
-
-        Return:
-        None.
         """
         try:
             ipaddress.ip_address(server_addr)

--- a/slips_files/core/database/redis_db/database.py
+++ b/slips_files/core/database/redis_db/database.py
@@ -1793,6 +1793,42 @@ class RedisDB(
         # delete anything older than the most recent 20 servers
         self.r.ltrim(self.constants.DHCP_SERVERS, 0, max - 1)
 
+    def is_official_dns_server(self, ip: str) -> bool:
+        """
+        Check whether the given IP is one of the configured DNS servers.
+
+        Parameters:
+        ip: IP address to check.
+
+        Return:
+        bool: True when the IP is stored as an official DNS server.
+        """
+        try:
+            ipaddress.ip_address(ip)
+        except ValueError:
+            return False
+
+        return bool(
+            self.r.sismember(self.constants.OFFICIAL_DNS_SERVERS, ip)
+        )
+
+    def store_official_dns_server(self, server_addr: str):
+        """
+        Store a configured DNS server IP in the database.
+
+        Parameters:
+        server_addr: DNS server IPv4 or IPv6 address.
+
+        Return:
+        None.
+        """
+        try:
+            ipaddress.ip_address(server_addr)
+        except ValueError:
+            return
+
+        self.r.sadd(self.constants.OFFICIAL_DNS_SERVERS, server_addr)
+
     def _get_redis_dump_path_from_redis_config(self) -> str:
         """
         Return the dump file path configured in the running Redis server.

--- a/slips_files/core/helpers/localnet_handler.py
+++ b/slips_files/core/helpers/localnet_handler.py
@@ -1,7 +1,6 @@
 import ipaddress
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
 from typing import Dict, List, Union
-import validators
 
 import netifaces
 
@@ -61,18 +60,23 @@ class LocalnetHandler:
         """
         local_nets = {}
         for interface in utils.get_all_interfaces(self.profiler.args):
-            addrs = netifaces.ifaddresses(interface).get(netifaces.AF_INET)
-            if not addrs:
-                return local_nets
+            iface_addrs = netifaces.ifaddresses(interface)
 
-            for addr in addrs:
-                ip = addr.get("addr")
-                netmask = addr.get("netmask")
-                if ip and netmask:
-                    network = ipaddress.IPv4Network(
-                        f"{ip}/{netmask}", strict=False
-                    )
-                    local_nets[interface] = str(network)
+            for family in (netifaces.AF_INET, netifaces.AF_INET6):
+                addrs = iface_addrs.get(family, [])
+                for addr in addrs:
+                    ip = (addr.get("addr") or "").split("%", 1)[0]
+                    netmask = addr.get("netmask") or addr.get("prefixlen")
+                    if isinstance(netmask, str) and "/" in netmask:
+                        netmask = netmask.rsplit("/", 1)[-1]
+                    if ip and netmask:
+                        network = ipaddress.ip_network(
+                            f"{ip}/{netmask}", strict=False
+                        )
+                        local_nets[interface] = str(network)
+                        break
+                if interface in local_nets:
+                    break
         return local_nets
 
     def _get_local_net_of_flow(self, flow) -> Dict[str, str]:
@@ -121,7 +125,7 @@ class LocalnetHandler:
 
     def _should_set_localnet(self, flow) -> bool:
         """
-        returns true only if the saddr of the current flow is ipv4, private
+        returns true only if the saddr of the current flow is private
         and we don't have the local_net set already
         """
         if self.done_recognizing_all_localnets:
@@ -150,10 +154,10 @@ class LocalnetHandler:
         if self._private_client_ips:
             return True
 
-        if not validators.ipv4(flow.saddr):
+        try:
+            saddr_obj = ipaddress.ip_address(flow.saddr)
+        except ValueError:
             return False
-
-        saddr_obj = ipaddress.ip_address(flow.saddr)
 
         if (
             saddr_obj.is_multicast

--- a/slips_files/core/helpers/localnet_handler.py
+++ b/slips_files/core/helpers/localnet_handler.py
@@ -56,7 +56,8 @@ class LocalnetHandler:
         self,
     ) -> Dict[str, str]:
         """
-        returns the local network of the given interface/s (-i or -ap)
+        returns the ipv4 and ipv6 local networks of the given interface/s
+        when slips is running with (-i or -ap)
         """
         local_nets = {}
         for interface in utils.get_all_interfaces(self.profiler.args):

--- a/tests/module_factory.py
+++ b/tests/module_factory.py
@@ -4,6 +4,7 @@ import shutil
 import importlib.util
 import sys
 from contextlib import contextmanager
+from types import ModuleType
 from unittest.mock import (
     patch,
     Mock,
@@ -686,6 +687,17 @@ class ModuleFactory:
         from slips_files.common.slips_utils import utils
 
         return utils
+
+    def create_flow_alert_utils_obj(self) -> ModuleType:
+        """
+        Create a flow alerts utils module instance for unit tests.
+
+        Return:
+        ModuleType: The flow alerts utils module.
+        """
+        from modules.flow_alerts import utils as flow_alert_utils
+
+        return flow_alert_utils
 
     @patch(MODULE_DB_MANAGER, name="mock_db")
     def create_threatintel_obj(self, mock_db):

--- a/tests/unit/modules/flow_alerts/test_conn.py
+++ b/tests/unit/modules/flow_alerts/test_conn.py
@@ -1342,6 +1342,87 @@ def test_check_connection_to_local_ip(
 
 
 @pytest.mark.parametrize(
+    "saddr, daddr, sport, dport, official_dns_ip",
+    [
+        ("192.168.1.20", "192.168.1.53", "40000", "53", ""),
+        ("fd00::53", "fd00::10", "547", "546", ""),
+        ("fd00::10", "fd00::53", "546", "547", ""),
+    ],
+)
+def test_check_connection_to_local_ip_ignores_official_dns_server(
+    saddr, daddr, sport, dport, official_dns_ip
+):
+    conn = ModuleFactory().create_conn_analyzer_obj()
+    conn.set_evidence.conn_to_private_ip = Mock()
+    conn.db.get_gateway_ip.return_value = "192.168.1.1"
+    conn.db.is_official_dns_server.side_effect = (
+        lambda ip: ip == official_dns_ip
+    )
+    flow = Conn(
+        starttime="1726249372.312124",
+        uid="123",
+        saddr=saddr,
+        daddr=daddr,
+        dur=1,
+        proto="udp",
+        appproto="",
+        sport=sport,
+        dport=dport,
+        spkts=0,
+        dpkts=0,
+        sbytes=0,
+        dbytes=0,
+        smac="",
+        dmac="",
+        state="Established",
+        history="",
+    )
+
+    conn.check_connection_to_local_ip(twid, flow)
+
+    conn.set_evidence.conn_to_private_ip.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "saddr, daddr, sport, dport",
+    [
+        ("fd00::10", "fd00::53", "40000", "53"),
+        ("fd00::53", "fd00::10", "547", "546"),
+        ("fd00::10", "fd00::53", "546", "547"),
+    ],
+)
+def test_check_connection_to_local_ip_ignores_dns_and_dhcpv6_service_ports(
+    saddr, daddr, sport, dport
+):
+    conn = ModuleFactory().create_conn_analyzer_obj()
+    conn.set_evidence.conn_to_private_ip = Mock()
+    conn.db.get_gateway_ip.return_value = "192.168.1.1"
+    flow = Conn(
+        starttime="1726249372.312124",
+        uid="123",
+        saddr=saddr,
+        daddr=daddr,
+        dur=1,
+        proto="udp",
+        appproto="",
+        sport=sport,
+        dport=dport,
+        spkts=0,
+        dpkts=0,
+        sbytes=0,
+        dbytes=0,
+        smac="",
+        dmac="",
+        state="Established",
+        history="",
+    )
+
+    conn.check_connection_to_local_ip(twid, flow)
+
+    conn.set_evidence.conn_to_private_ip.assert_not_called()
+
+
+@pytest.mark.parametrize(
     "msg, expected_result",
     [
         (

--- a/tests/unit/modules/flow_alerts/test_conn.py
+++ b/tests/unit/modules/flow_alerts/test_conn.py
@@ -1178,6 +1178,22 @@ def test_is_well_known_org(
             "srcip",
             0,
         ),
+        (  # Test case 5: Different IPv6 local network usage (dstip)
+            "fd00:1::10",
+            "fd00:2::20",
+            80,
+            "tcp",
+            "dstip",
+            1,
+        ),
+        (  # Test case 6: Same IPv6 local network usage, no evidence
+            "fd00:1::10",
+            "fd00:1::20",
+            80,
+            "tcp",
+            "dstip",
+            0,
+        ),
     ],
 )
 def test_check_different_localnet_usage(
@@ -1189,7 +1205,11 @@ def test_check_different_localnet_usage(
     """
     conn = ModuleFactory().create_conn_analyzer_obj()
     conn.set_evidence.different_localnet_usage = Mock()
-    conn.db.get_local_network.return_value = "192.168.1.0/24"
+    conn.db.get_local_network.return_value = (
+        "fd00:1::/64"
+        if ":" in saddr or ":" in daddr
+        else "192.168.1.0/24"
+    )
     flow = Conn(
         starttime="1726249372.312124",
         uid="123",

--- a/tests/unit/modules/flow_alerts/test_conn.py
+++ b/tests/unit/modules/flow_alerts/test_conn.py
@@ -7,7 +7,6 @@ from tests.module_factory import ModuleFactory
 import json
 from unittest.mock import (
     Mock,
-    patch,
 )
 import pytest
 from ipaddress import ip_address
@@ -532,24 +531,6 @@ def test_check_tor_exit_node(
     assert conn.check_tor_exit_node(twid, flow) is expected_result
     conn.db.is_tor_node.assert_called_once_with(flow.daddr)
     assert mock_set_evidence.call_count == expected_call_count
-
-
-@pytest.mark.parametrize(
-    "mock_time_diff, expected_result",
-    [
-        (40, True),  # Timeout reached
-        (20, False),  # Timeout not reached
-    ],
-)
-def test_is_interface_timeout_reached(mock_time_diff, expected_result):
-    conn = ModuleFactory().create_conn_analyzer_obj()
-    conn.is_running_non_stop = True
-    conn.conn_without_dns_interface_wait_time = 30
-    with patch(
-        "slips_files.common.slips_utils.utils.get_time_diff",
-        return_value=mock_time_diff,
-    ):
-        assert conn.is_interface_timeout_reached() == expected_result
 
 
 @pytest.mark.parametrize(
@@ -1206,9 +1187,7 @@ def test_check_different_localnet_usage(
     conn = ModuleFactory().create_conn_analyzer_obj()
     conn.set_evidence.different_localnet_usage = Mock()
     conn.db.get_local_network.return_value = (
-        "fd00:1::/64"
-        if ":" in saddr or ":" in daddr
-        else "192.168.1.0/24"
+        "fd00:1::/64" if ":" in saddr or ":" in daddr else "192.168.1.0/24"
     )
     flow = Conn(
         starttime="1726249372.312124",

--- a/tests/unit/modules/flow_alerts/test_conn.py
+++ b/tests/unit/modules/flow_alerts/test_conn.py
@@ -1239,6 +1239,49 @@ def test_check_different_localnet_usage(
 
 
 @pytest.mark.parametrize(
+    "what_to_check, sport, dport",
+    [
+        ("dstip", "40000", "53"),
+        ("srcip", "53", "40000"),
+    ],
+)
+def test_check_different_localnet_usage_ignores_official_dns_server(
+    what_to_check, sport, dport
+):
+    conn = ModuleFactory().create_conn_analyzer_obj()
+    conn.set_evidence.different_localnet_usage = Mock()
+    conn.db.get_local_network.return_value = "fd00:1::/64"
+    conn.db.is_official_dns_server.return_value = True
+    flow = Conn(
+        starttime="1726249372.312124",
+        uid="123",
+        saddr="fd00:2::53",
+        daddr="fd00:3::53",
+        dur=1,
+        proto="tcp",
+        appproto="",
+        sport=sport,
+        dport=dport,
+        spkts=0,
+        dpkts=0,
+        sbytes=0,
+        dbytes=0,
+        smac="",
+        dmac="",
+        state="Established",
+        history="",
+    )
+
+    conn.check_different_localnet_usage(
+        twid,
+        flow,
+        what_to_check=what_to_check,
+    )
+
+    conn.set_evidence.different_localnet_usage.assert_not_called()
+
+
+@pytest.mark.parametrize(
     "daddr, dport, proto, saddr, expected_calls",
     [
         (  # Test case 1: Both IPs are private,

--- a/tests/unit/modules/flow_alerts/test_dns.py
+++ b/tests/unit/modules/flow_alerts/test_dns.py
@@ -178,32 +178,9 @@ def test_extract_ips_from_dns_answers():
     assert extracted_ips == ["192.168.1.1", "2001:db8::1"]
 
 
-def test_is_ok_to_connect_to_ip_outside_localnet_requires_detected_private_ipv6_dns_server():
-    dns = ModuleFactory().create_dns_analyzer_obj()
-    flow = DNS(
-        starttime="1726568479.5997488",
-        uid="1234",
-        saddr="fd00:1::10",
-        daddr="fd00:2::53",
-        dport="53",
-        sport="53000",
-        proto="udp",
-        query="example.com",
-        qclass_name="",
-        qtype_name="AAAA",
-        rcode_name="NOERROR",
-        answers=[],
-        TTLs="",
-    )
-
-    dns.db.is_official_dns_server.return_value = True
-
-    assert dns._is_ok_to_connect_to_ip_outside_localnet(flow) is False
-
-
 def test_dns_misconfiguration_detection_tracks_private_ipv6_dns_server():
     dns = ModuleFactory().create_dns_analyzer_obj()
-    dns.db.is_official_dns_server.return_value = False
+    dns.db.is_official_dns_server.return_value = True
     flow = DNS(
         starttime="1726568479.5997488",
         uid="1234",
@@ -222,11 +199,7 @@ def test_dns_misconfiguration_detection_tracks_private_ipv6_dns_server():
 
     assert dns.is_possible_dns_misconfiguration(flow.daddr, flow) is True
 
-    assert dns.detected_dns_ip == "fd00:2::53"
-    dns.db.store_official_dns_server.assert_called_once_with("fd00:2::53")
-    dns.flowalerts.print.assert_called_with(
-        "Detected DNS server by traffic heuristic: fd00:2::53"
-    )
+    dns.db.is_official_dns_server.assert_called_once_with("fd00:2::53")
 
 
 @pytest.mark.parametrize(
@@ -261,31 +234,9 @@ def test_check_different_localnet_usage_ignores_official_dns_server(
 
     dns.check_different_localnet_usage(twid, flow, what_to_check=what_to_check)
 
-    assert dns.set_evidence.different_localnet_usage.call_count == expected_calls
-
-
-def test_register_private_dns_server_ignores_public_dns_server():
-    dns = ModuleFactory().create_dns_analyzer_obj()
-    dns.db.is_official_dns_server.return_value = False
-    flow = DNS(
-        starttime="1726568479.5997488",
-        uid="1234",
-        saddr="fd00:1::10",
-        daddr="8.8.8.8",
-        dport="53",
-        sport="53000",
-        proto="udp",
-        query="example.com",
-        qclass_name="",
-        qtype_name="A",
-        rcode_name="NOERROR",
-        answers=["8.8.4.4"],
-        TTLs="",
+    assert (
+        dns.set_evidence.different_localnet_usage.call_count == expected_calls
     )
-
-    assert dns.register_private_dns_server(flow) is False
-    dns.db.store_official_dns_server.assert_not_called()
-    dns.flowalerts.print.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/modules/flow_alerts/test_dns.py
+++ b/tests/unit/modules/flow_alerts/test_dns.py
@@ -225,6 +225,41 @@ def test_dns_misconfiguration_detection_tracks_private_ipv6_dns_server():
 
 
 @pytest.mark.parametrize(
+    "what_to_check, expected_calls",
+    [
+        ("dstip", 0),
+        ("srcip", 0),
+    ],
+)
+def test_check_different_localnet_usage_ignores_official_dns_server(
+    what_to_check, expected_calls
+):
+    dns = ModuleFactory().create_dns_analyzer_obj()
+    dns.set_evidence.different_localnet_usage = Mock()
+    dns.db.get_local_network.return_value = "fd00:1::/64"
+    dns.db.is_official_dns_server.return_value = True
+    flow = DNS(
+        starttime="1726568479.5997488",
+        uid="1234",
+        saddr="fd00:2::53",
+        daddr="fd00:3::53",
+        dport="53",
+        sport="53",
+        proto="udp",
+        query="example.com",
+        qclass_name="",
+        qtype_name="AAAA",
+        rcode_name="NOERROR",
+        answers=["2001:db8::1"],
+        TTLs="",
+    )
+
+    dns.check_different_localnet_usage(twid, flow, what_to_check=what_to_check)
+
+    assert dns.set_evidence.different_localnet_usage.call_count == expected_calls
+
+
+@pytest.mark.parametrize(
     "contacted_ips, other_ip, expected_result",
     [  # Testcase1: Connection exists from other IP version
         (["8.8.8.8"], ["192.168.1.2"], True),

--- a/tests/unit/modules/flow_alerts/test_dns.py
+++ b/tests/unit/modules/flow_alerts/test_dns.py
@@ -178,7 +178,7 @@ def test_extract_ips_from_dns_answers():
     assert extracted_ips == ["192.168.1.1", "2001:db8::1"]
 
 
-def test_is_ok_to_connect_to_ip_outside_localnet_handles_private_ipv6():
+def test_is_ok_to_connect_to_ip_outside_localnet_requires_detected_private_ipv6_dns_server():
     dns = ModuleFactory().create_dns_analyzer_obj()
     flow = DNS(
         starttime="1726568479.5997488",
@@ -196,11 +196,14 @@ def test_is_ok_to_connect_to_ip_outside_localnet_handles_private_ipv6():
         TTLs="",
     )
 
-    assert dns._is_ok_to_connect_to_ip_outside_localnet(flow) is True
+    dns.db.is_official_dns_server.return_value = True
+
+    assert dns._is_ok_to_connect_to_ip_outside_localnet(flow) is False
 
 
 def test_dns_misconfiguration_detection_tracks_private_ipv6_dns_server():
     dns = ModuleFactory().create_dns_analyzer_obj()
+    dns.db.is_official_dns_server.return_value = False
     flow = DNS(
         starttime="1726568479.5997488",
         uid="1234",
@@ -217,11 +220,13 @@ def test_dns_misconfiguration_detection_tracks_private_ipv6_dns_server():
         TTLs="",
     )
 
-    for _ in range(5):
-        assert dns.is_possible_dns_misconfiguration(flow.daddr, flow) is True
+    assert dns.is_possible_dns_misconfiguration(flow.daddr, flow) is True
 
-    assert dns.is_dns_detected is True
     assert dns.detected_dns_ip == "fd00:2::53"
+    dns.db.store_official_dns_server.assert_called_once_with("fd00:2::53")
+    dns.flowalerts.print.assert_called_with(
+        "Detected DNS server by traffic heuristic: fd00:2::53"
+    )
 
 
 @pytest.mark.parametrize(
@@ -257,6 +262,30 @@ def test_check_different_localnet_usage_ignores_official_dns_server(
     dns.check_different_localnet_usage(twid, flow, what_to_check=what_to_check)
 
     assert dns.set_evidence.different_localnet_usage.call_count == expected_calls
+
+
+def test_register_private_dns_server_ignores_public_dns_server():
+    dns = ModuleFactory().create_dns_analyzer_obj()
+    dns.db.is_official_dns_server.return_value = False
+    flow = DNS(
+        starttime="1726568479.5997488",
+        uid="1234",
+        saddr="fd00:1::10",
+        daddr="8.8.8.8",
+        dport="53",
+        sport="53000",
+        proto="udp",
+        query="example.com",
+        qclass_name="",
+        qtype_name="A",
+        rcode_name="NOERROR",
+        answers=["8.8.4.4"],
+        TTLs="",
+    )
+
+    assert dns.register_private_dns_server(flow) is False
+    dns.db.store_official_dns_server.assert_not_called()
+    dns.flowalerts.print.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/modules/flow_alerts/test_dns.py
+++ b/tests/unit/modules/flow_alerts/test_dns.py
@@ -178,6 +178,52 @@ def test_extract_ips_from_dns_answers():
     assert extracted_ips == ["192.168.1.1", "2001:db8::1"]
 
 
+def test_is_ok_to_connect_to_ip_outside_localnet_handles_private_ipv6():
+    dns = ModuleFactory().create_dns_analyzer_obj()
+    flow = DNS(
+        starttime="1726568479.5997488",
+        uid="1234",
+        saddr="fd00:1::10",
+        daddr="fd00:2::53",
+        dport="53",
+        sport="53000",
+        proto="udp",
+        query="example.com",
+        qclass_name="",
+        qtype_name="AAAA",
+        rcode_name="NOERROR",
+        answers=[],
+        TTLs="",
+    )
+
+    assert dns._is_ok_to_connect_to_ip_outside_localnet(flow) is True
+
+
+def test_dns_misconfiguration_detection_tracks_private_ipv6_dns_server():
+    dns = ModuleFactory().create_dns_analyzer_obj()
+    flow = DNS(
+        starttime="1726568479.5997488",
+        uid="1234",
+        saddr="fd00:1::10",
+        daddr="fd00:2::53",
+        dport="53",
+        sport="53000",
+        proto="udp",
+        query="example.com",
+        qclass_name="",
+        qtype_name="AAAA",
+        rcode_name="NOERROR",
+        answers=["2001:db8::1"],
+        TTLs="",
+    )
+
+    for _ in range(5):
+        assert dns.is_possible_dns_misconfiguration(flow.daddr, flow) is True
+
+    assert dns.is_dns_detected is True
+    assert dns.detected_dns_ip == "fd00:2::53"
+
+
 @pytest.mark.parametrize(
     "contacted_ips, other_ip, expected_result",
     [  # Testcase1: Connection exists from other IP version

--- a/tests/unit/modules/flow_alerts/test_utils.py
+++ b/tests/unit/modules/flow_alerts/test_utils.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Garcia <sebastian.garcia@agents.fel.cvut.cz>
+# SPDX-License-Identifier: GPL-2.0-only
+"""Unit tests for modules/flow_alerts/utils.py"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tests.module_factory import ModuleFactory
+
+
+@pytest.mark.parametrize(
+    "what_to_check, expected_ip",
+    [
+        ("srcip", "192.168.1.10"),
+        ("dstip", "192.168.1.20"),
+        ("invalid", ""),
+    ],
+)
+def test_get_ip_to_check(what_to_check: str, expected_ip: str) -> None:
+    """Test selecting the IP address requested by the check direction."""
+    module_factory = ModuleFactory()
+    flow_alert_utils = module_factory.create_flow_alert_utils_obj()
+    flow = SimpleNamespace(saddr="192.168.1.10", daddr="192.168.1.20")
+
+    assert flow_alert_utils.get_ip_to_check(flow, what_to_check) == expected_ip
+
+
+@pytest.mark.parametrize(
+    "dport, proto, expected_result",
+    [
+        ("53", "udp", True),
+        (53, "UDP", True),
+        ("53", "tcp", False),
+        ("443", "udp", False),
+    ],
+)
+def test_is_dns_flow(
+    dport: str | int, proto: str, expected_result: bool
+) -> None:
+    """Test DNS flow detection by destination port and protocol."""
+    module_factory = ModuleFactory()
+    flow_alert_utils = module_factory.create_flow_alert_utils_obj()
+    flow = SimpleNamespace(dport=dport, proto=proto)
+
+    assert flow_alert_utils.is_dns_flow(flow) is expected_result
+
+
+@pytest.mark.parametrize(
+    "ip, expected_result",
+    [
+        ("0.0.0.0", True),
+        ("255.255.255.255", True),
+        ("127.0.0.1", True),
+        ("224.0.0.1", True),
+        ("169.254.1.1", True),
+        ("192.168.1.10", False),
+    ],
+)
+def test_is_ignored_localnet_ip(ip: str, expected_result: bool) -> None:
+    """Test IPs ignored by different-localnet detection."""
+    module_factory = ModuleFactory()
+    flow_alert_utils = module_factory.create_flow_alert_utils_obj()
+
+    assert flow_alert_utils.is_ignored_localnet_ip(ip) is expected_result
+
+
+@pytest.mark.parametrize(
+    "ip, expected_result",
+    [
+        ("8.8.8.8", True),
+        ("127.0.0.1", True),
+        ("169.254.1.1", True),
+        ("192.168.1.10", False),
+        ("fd00:1::10", False),
+    ],
+)
+def test_is_ip_allowed_outside_localnet(
+    ip: str, expected_result: bool
+) -> None:
+    """Test IPs that should not produce different-localnet evidence."""
+    module_factory = ModuleFactory()
+    flow_alert_utils = module_factory.create_flow_alert_utils_obj()
+
+    assert (
+        flow_alert_utils.is_ip_allowed_outside_localnet(ip) is expected_result
+    )
+
+
+@pytest.mark.parametrize(
+    "saddr, daddr, dport, proto, skip_dns_flows, expected_result",
+    [
+        ("192.168.1.10", "192.168.2.20", "80", "tcp", True, True),
+        ("8.8.8.8", "192.168.2.20", "80", "tcp", True, True),
+        ("192.168.1.10", "8.8.8.8", "80", "tcp", True, False),
+        ("192.168.1.10", "192.168.2.20", "53", "udp", True, False),
+        ("192.168.1.10", "192.168.2.20", "53", "udp", False, True),
+        ("fd00:1::10", "192.168.2.20", "80", "tcp", True, False),
+    ],
+)
+def test_should_check_different_localnet(
+    saddr: str,
+    daddr: str,
+    dport: str,
+    proto: str,
+    skip_dns_flows: bool,
+    expected_result: bool,
+) -> None:
+    """Test common eligibility checks for different-localnet evidence."""
+    module_factory = ModuleFactory()
+    flow_alert_utils = module_factory.create_flow_alert_utils_obj()
+    flow = SimpleNamespace(
+        saddr=saddr,
+        daddr=daddr,
+        dport=dport,
+        proto=proto,
+    )
+
+    assert (
+        flow_alert_utils.should_check_different_localnet(
+            flow,
+            skip_dns_flows=skip_dns_flows,
+        )
+        is expected_result
+    )
+
+
+def test_should_check_different_localnet_ignores_dns_server() -> None:
+    """Test skipping flows involving detected official DNS servers."""
+    module_factory = ModuleFactory()
+    flow_alert_utils = module_factory.create_flow_alert_utils_obj()
+    db = Mock()
+    db.is_official_dns_server.side_effect = lambda ip: ip == "192.168.2.53"
+    flow = SimpleNamespace(
+        saddr="192.168.1.10",
+        daddr="192.168.2.53",
+        dport="53",
+        proto="udp",
+    )
+
+    assert (
+        flow_alert_utils.should_check_different_localnet(
+            flow,
+            db=db,
+            ignore_official_dns_servers=True,
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    "ip_to_check, local_network, expected_result",
+    [
+        ("192.168.2.20", "192.168.1.0/24", True),
+        ("192.168.1.20", "192.168.1.0/24", False),
+        ("fd00:2::20", "fd00:1::/64", True),
+        ("192.168.2.20", "fd00:1::/64", False),
+        ("192.168.2.20", "", False),
+    ],
+)
+def test_is_ip_outside_local_network(
+    ip_to_check: str, local_network: str, expected_result: bool
+) -> None:
+    """Test local-network membership checks."""
+    module_factory = ModuleFactory()
+    flow_alert_utils = module_factory.create_flow_alert_utils_obj()
+    db = Mock()
+    db.get_local_network.return_value = local_network
+    flow = SimpleNamespace(interface="eth0")
+
+    assert (
+        flow_alert_utils.is_ip_outside_local_network(db, flow, ip_to_check)
+        is expected_result
+    )
+
+
+@pytest.mark.parametrize(
+    "is_running_non_stop, time_diff, expected_result",
+    [
+        (False, 0, True),
+        (True, 40, True),
+        (True, 20, False),
+    ],
+)
+def test_is_interface_timeout_reached(
+    is_running_non_stop: bool, time_diff: int, expected_result: bool
+) -> None:
+    """Test interface startup grace-period handling."""
+    module_factory = ModuleFactory()
+    flow_alert_utils = module_factory.create_flow_alert_utils_obj()
+    db = Mock()
+    db.get_slips_start_time.return_value = "2026-06-04 12:00:00"
+
+    with patch(
+        "slips_files.common.slips_utils.utils.get_time_diff",
+        return_value=time_diff,
+    ):
+        assert (
+            flow_alert_utils.is_interface_timeout_reached(
+                db,
+                is_running_non_stop,
+                wait_time=30,
+            )
+            is expected_result
+        )

--- a/tests/unit/modules/ip_info/test_ip_info.py
+++ b/tests/unit/modules/ip_info/test_ip_info.py
@@ -594,7 +594,6 @@ def test_register_private_dns_server_stores_private_dns_server():
 
     assert ip_info.register_private_dns_server(flow) is True
 
-    assert ip_info.detected_dns_ip == "fd00:2::53"
     ip_info.db.store_official_dns_server.assert_called_once_with("fd00:2::53")
     ip_info.print.assert_called_once_with(
         "Detected DNS server by traffic heuristic: fd00:2::53"

--- a/tests/unit/modules/ip_info/test_ip_info.py
+++ b/tests/unit/modules/ip_info/test_ip_info.py
@@ -15,6 +15,7 @@ from unittest.mock import (
 import json
 import requests
 import socket
+from slips_files.core.flows.zeek import DNS
 from slips_files.core.structures.evidence import (
     ThreatLevel,
     Evidence,
@@ -570,6 +571,68 @@ def test_check_if_we_have_pending_mac_queries_empty_queue(
     mock_get_vendor = mocker.patch.object(ip_info, "get_vendor")
     ip_info.check_if_we_have_pending_offline_mac_queries()
     mock_get_vendor.assert_not_called()
+
+
+def test_register_private_dns_server_stores_private_dns_server():
+    ip_info = ModuleFactory().create_ip_info_obj()
+    ip_info.db.is_official_dns_server.return_value = False
+    flow = DNS(
+        starttime="1726568479.5997488",
+        uid="1234",
+        saddr="fd00:1::10",
+        daddr="fd00:2::53",
+        dport="53",
+        sport="53000",
+        proto="udp",
+        query="example.com",
+        qclass_name="",
+        qtype_name="AAAA",
+        rcode_name="NOERROR",
+        answers=["2001:db8::1"],
+        TTLs="",
+    )
+
+    assert ip_info.register_private_dns_server(flow) is True
+
+    assert ip_info.detected_dns_ip == "fd00:2::53"
+    ip_info.db.store_official_dns_server.assert_called_once_with("fd00:2::53")
+    ip_info.print.assert_called_once_with(
+        "Detected DNS server by traffic heuristic: fd00:2::53"
+    )
+
+
+@pytest.mark.parametrize(
+    "daddr, dport, proto",
+    [
+        ("8.8.8.8", "53", "udp"),
+        ("fd00:2::53", "5353", "udp"),
+        ("fd00:2::53", "53", "tcp"),
+    ],
+)
+def test_register_private_dns_server_ignores_non_private_dns_server_flows(
+    daddr, dport, proto
+):
+    ip_info = ModuleFactory().create_ip_info_obj()
+    flow = DNS(
+        starttime="1726568479.5997488",
+        uid="1234",
+        saddr="fd00:1::10",
+        daddr=daddr,
+        dport=dport,
+        sport="53000",
+        proto=proto,
+        query="example.com",
+        qclass_name="",
+        qtype_name="A",
+        rcode_name="NOERROR",
+        answers=["8.8.4.4"],
+        TTLs="",
+    )
+
+    assert ip_info.register_private_dns_server(flow) is False
+
+    ip_info.db.store_official_dns_server.assert_not_called()
+    ip_info.print.assert_not_called()
 
 
 @pytest.fixture

--- a/tests/unit/modules/ip_info/test_ip_info.py
+++ b/tests/unit/modules/ip_info/test_ip_info.py
@@ -481,44 +481,6 @@ def test_get_gateway_ip_if_interface_args_interface(
     )
 
 
-@pytest.mark.parametrize(
-    "nameservers, expected_dns_servers",
-    [
-        (["192.168.1.53", "fd00::53"], ["192.168.1.53", "fd00::53"]),
-        (["192.168.1.53", "invalid"], ["192.168.1.53"]),
-        ([], []),
-    ],
-)
-def test_get_configured_dns_server_ips(
-    mocker, nameservers, expected_dns_servers
-):
-    ip_info = ModuleFactory().create_ip_info_obj()
-    resolver = Mock(nameservers=nameservers)
-    mocker.patch(
-        "modules.ip_info.ip_info.dns.resolver.Resolver",
-        return_value=resolver,
-    )
-
-    assert ip_info.get_configured_dns_server_ips() == expected_dns_servers
-
-
-def test_pre_main_stores_configured_dns_servers(mocker):
-    ip_info = ModuleFactory().create_ip_info_obj()
-    ip_info.wait_for_dbs = Mock()
-    ip_info.get_gateway_ip_if_interface = Mock(return_value={})
-    ip_info.get_configured_dns_server_ips = Mock(
-        return_value=["192.168.1.53", "fd00::53"]
-    )
-    mocker.patch(
-        "slips_files.common.slips_utils.utils.drop_root_privs_permanently"
-    )
-
-    ip_info.pre_main()
-
-    ip_info.db.store_official_dns_server.assert_any_call("192.168.1.53")
-    ip_info.db.store_official_dns_server.assert_any_call("fd00::53")
-
-
 # def test_get_gateway_ip_if_interface_args_access_point():
 
 

--- a/tests/unit/modules/ip_info/test_ip_info.py
+++ b/tests/unit/modules/ip_info/test_ip_info.py
@@ -481,6 +481,44 @@ def test_get_gateway_ip_if_interface_args_interface(
     )
 
 
+@pytest.mark.parametrize(
+    "nameservers, expected_dns_servers",
+    [
+        (["192.168.1.53", "fd00::53"], ["192.168.1.53", "fd00::53"]),
+        (["192.168.1.53", "invalid"], ["192.168.1.53"]),
+        ([], []),
+    ],
+)
+def test_get_configured_dns_server_ips(
+    mocker, nameservers, expected_dns_servers
+):
+    ip_info = ModuleFactory().create_ip_info_obj()
+    resolver = Mock(nameservers=nameservers)
+    mocker.patch(
+        "modules.ip_info.ip_info.dns.resolver.Resolver",
+        return_value=resolver,
+    )
+
+    assert ip_info.get_configured_dns_server_ips() == expected_dns_servers
+
+
+def test_pre_main_stores_configured_dns_servers(mocker):
+    ip_info = ModuleFactory().create_ip_info_obj()
+    ip_info.wait_for_dbs = Mock()
+    ip_info.get_gateway_ip_if_interface = Mock(return_value={})
+    ip_info.get_configured_dns_server_ips = Mock(
+        return_value=["192.168.1.53", "fd00::53"]
+    )
+    mocker.patch(
+        "slips_files.common.slips_utils.utils.drop_root_privs_permanently"
+    )
+
+    ip_info.pre_main()
+
+    ip_info.db.store_official_dns_server.assert_any_call("192.168.1.53")
+    ip_info.db.store_official_dns_server.assert_any_call("fd00::53")
+
+
 # def test_get_gateway_ip_if_interface_args_access_point():
 
 

--- a/tests/unit/slips_files/core/database/test_database.py
+++ b/tests/unit/slips_files/core/database/test_database.py
@@ -201,7 +201,7 @@ def test_redis_db_is_tor_node():
 
 
 def test_store_official_dns_server():
-    """Test storing configured DNS servers in Redis."""
+    """Test storing detected DNS servers in Redis."""
     db = ModuleFactory().create_db_manager_obj(6379, flush_db=True)
 
     db.store_official_dns_server("192.168.1.53")

--- a/tests/unit/slips_files/core/database/test_database.py
+++ b/tests/unit/slips_files/core/database/test_database.py
@@ -200,6 +200,18 @@ def test_redis_db_is_tor_node():
     )
 
 
+def test_store_official_dns_server():
+    """Test storing configured DNS servers in Redis."""
+    db = ModuleFactory().create_db_manager_obj(6379, flush_db=True)
+
+    db.store_official_dns_server("192.168.1.53")
+    db.store_official_dns_server("fd00::53")
+
+    assert db.is_official_dns_server("192.168.1.53") is True
+    assert db.is_official_dns_server("fd00::53") is True
+    assert db.is_official_dns_server("not-an-ip") is False
+
+
 def test_setup_config_file_uses_isolated_path_and_preserves_save(
     tmp_path, monkeypatch
 ):

--- a/tests/unit/slips_files/core/helpers/test_localnet_handler.py
+++ b/tests/unit/slips_files/core/helpers/test_localnet_handler.py
@@ -57,6 +57,16 @@ def test_get_local_net_of_flow_prefers_configured_default_localnet():
     assert localnet == {"default": "192.168.1.0/24"}
 
 
+def test_get_local_net_of_flow_returns_ipv6_network():
+    profiler = create_profiler()
+    handler = LocalnetHandler(profiler)
+    flow = Mock(saddr="fd00:1::abcd")
+
+    localnet = handler._get_local_net_of_flow(flow)
+
+    assert localnet == {"default": "fd00:1::/64"}
+
+
 @patch("slips_files.core.helpers.localnet_handler.netifaces.ifaddresses")
 @patch("slips_files.core.helpers.localnet_handler.utils.get_all_interfaces")
 def test_get_localnet_of_given_interface_returns_ipv4_networks(
@@ -80,6 +90,25 @@ def test_get_localnet_of_given_interface_returns_ipv4_networks(
         "eth0": "192.168.1.0/24",
         "wlan0": "10.0.0.0/8",
     }
+
+
+@patch("slips_files.core.helpers.localnet_handler.netifaces.ifaddresses")
+@patch("slips_files.core.helpers.localnet_handler.utils.get_all_interfaces")
+def test_get_localnet_of_given_interface_returns_ipv6_networks(
+    mock_get_all_interfaces, mock_ifaddresses
+):
+    profiler = create_profiler(running_non_stop=True)
+    handler = LocalnetHandler(profiler)
+    mock_get_all_interfaces.return_value = ["eth0"]
+    mock_ifaddresses.return_value = {
+        netifaces.AF_INET6: [
+            {"addr": "fd00:1::1234%eth0", "prefixlen": "64"}
+        ]
+    }
+
+    localnets = handler._get_localnet_of_given_interfaces_using_netifaces()
+
+    assert localnets == {"eth0": "fd00:1::/64"}
 
 
 def test_handle_setting_local_net_updates_cache_and_db():
@@ -136,6 +165,7 @@ def test_handle_setting_local_net_updates_cache_and_db():
         (False, {}, [], "224.0.0.1", "eth0", True, False),
         (False, {}, [], "8.8.8.8", "eth0", False, False),
         (False, {}, [], "192.168.1.8", "eth0", False, True),
+        (False, {}, [], "fd00:1::abcd", "eth0", False, True),
     ],
 )
 def test_should_set_localnet(


### PR DESCRIPTION
This PR is to add the capability to ingnore the DNS and DHCP connection to the local DNS server as found by heuristics. 
Both for ipv4 and ipv6

## Fixes Issue
There were alerts of packets to the local dns server reported as evidence 'info'

## Changes proposed
To detect ipv6 DNS server IP.
To check that if a dns or dhcp goes to any ipv4 or ipv6 IP then it should not be evidenced

## Steps you followed to test the changes purposed in this PR:
- all test pass
- new test were created


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
- [x] My PR is based on develop branch. (mandatory)
